### PR TITLE
3d video recording backend

### DIFF
--- a/interfaces/remoteOperatorUI/VideoFileManager.js
+++ b/interfaces/remoteOperatorUI/VideoFileManager.js
@@ -14,8 +14,6 @@ const utils = require('./utilities');
 let outputPath = null;
 let persistentInfo = null;
 
-// Private functions not exposed to other modules
-
 const createMissingDirs = (devicePath) => {
     utils.mkdirIfNeeded(devicePath);
     let dir = constants.DIR_NAMES;
@@ -125,6 +123,7 @@ module.exports = {
         outputPath = path;
         utils.mkdirIfNeeded(path, true);
     },
+    createMissingDirs: createMissingDirs,
     // we rebuild the json blob each time by parsing the filesystem, so this is stored mainly as a means for other systems to retrieve the data
     buildPersistentInfo: () => {
         if (!outputPath) { console.warn('You never called initWithOutputPath on VideoFileManager'); }

--- a/interfaces/remoteOperatorUI/VideoFileManager.js
+++ b/interfaces/remoteOperatorUI/VideoFileManager.js
@@ -1,0 +1,177 @@
+const fs = require('fs');
+const path = require('path');
+const constants = require('./videoConstants');
+
+/**
+ * @fileOverview
+ * The VideoFileManager is initialized with an outputPath where all video recordings and their derivatives are stored,
+ * and contains a variety of utilities for reading and writing the files to a specific nested file structure,
+ * and to convert this into a json blob containing the file tree (the persistentInfo).
+ * All state is reconstructed from the file structure when the server restarts.
+ */
+
+let outputPath = null;
+let persistentInfo = null;
+
+// Private functions not exposed to other modules
+
+const mkdirIfNeeded = (path, recursive) => { // helper function since we do this so often
+    let options = recursive ? {recursive: true} : undefined;
+    if (!fs.existsSync(path)) {
+        fs.mkdirSync(path, options);
+        console.log('VideoFileManager created directory: ' + path);
+    }
+};
+
+const createMissingDirs = (devicePath) => {
+    mkdirIfNeeded(devicePath);
+    let dir = constants.DIR_NAMES;
+
+    let sessionVideosPath = path.join(devicePath, dir.session_videos);
+    let unprocessedChunksPath = path.join(devicePath, dir.unprocessed_chunks);
+    let processedChunksPath = path.join(devicePath, dir.processed_chunks);
+
+    [dir.color, dir.depth, dir.pose].forEach(name => {
+        mkdirIfNeeded(path.join(sessionVideosPath, name), true);
+        mkdirIfNeeded(path.join(unprocessedChunksPath, name), true);
+        mkdirIfNeeded(path.join(processedChunksPath, name), true);
+    });
+};
+
+const parseDeviceDirectory = (devicePath) => {
+    let info = {};
+    createMissingDirs(devicePath);
+
+    // add fully-concatenated color and depth videos
+    let sessionVideosPath = path.join(devicePath, constants.DIR_NAMES.session_videos);
+    fs.readdirSync(path.join(sessionVideosPath, constants.DIR_NAMES.color)).forEach(filepath => {
+        let sessionId = getSessionIdFromFilename(filepath, 'session_');
+        if (sessionId && sessionId.length === 8) {
+            if (typeof info[sessionId] === 'undefined') {
+                info[sessionId] = {};
+            }
+            info[sessionId].color = filepath;
+            if (fs.existsSync(path.join(sessionVideosPath, constants.DIR_NAMES.depth, filepath))) {
+                info[sessionId].depth = filepath;
+            }
+        }
+    });
+    // append pose data separately from logic for color, since pose may be available before color & depth
+    fs.readdirSync(path.join(sessionVideosPath, 'pose')).forEach(filepath => {
+        let sessionId = getSessionIdFromFilename(filepath, 'session_');
+        if (sessionId && sessionId.length === 8) {
+            if (typeof info[sessionId] === 'undefined') {
+                info[sessionId] = {};
+            }
+            info[sessionId].pose = filepath;
+        }
+    });
+
+    // add the list of chunks (processed and unprocessed) to the json output
+    [constants.DIR_NAMES.processed_chunks, constants.DIR_NAMES.unprocessed_chunks].forEach(dirName => {
+        let thisPath = path.join(devicePath, dirName);
+        fs.readdirSync(path.join(thisPath, constants.DIR_NAMES.color)).forEach(filepath => { // do for color, but check for depth within the block to ensure both exist
+            let sessionId = getSessionIdFromFilename(filepath, 'chunk_');
+            if (sessionId && sessionId.length === 8) {
+                if (typeof info[sessionId] === 'undefined') {
+                    info[sessionId] = {};
+                }
+                if (typeof info[sessionId][dirName] === 'undefined') {
+                    info[sessionId][dirName] = [];
+                }
+                if (fs.existsSync(path.join(thisPath, constants.DIR_NAMES.depth, filepath))) {
+                    info[sessionId][dirName].push(filepath);
+                }
+            }
+        });
+    });
+
+    return info;
+};
+
+const getSessionIdFromFilename = (filename, prefix) => {
+    let re = new RegExp(prefix + '[a-zA-Z0-9]{8}');
+    let matches = filename.match(re);
+    if (!matches || matches.length === 0) { return null; }
+    return (prefix ? matches[0].replace(prefix, '') : matches[0]);
+};
+
+const getNestedFilePaths = (deviceId, dirName, colorOrDepth) => {
+    if (!outputPath) { console.warn('You never called initWithOutputPath on VideoFileManager'); }
+
+    let dirPath = path.join(outputPath, deviceId, dirName, colorOrDepth);
+    mkdirIfNeeded(dirPath, true);
+    let filetype = '.' + ((colorOrDepth === constants.DIR_NAMES.depth) ? constants.DEPTH_FILETYPE : constants.COLOR_FILETYPE);
+    return fs.readdirSync(dirPath).filter(filename => filename.includes(filetype));
+};
+
+const deleteChunksForSession = (deviceId, sessionId) => {
+    if (!outputPath) { console.warn('You never called initWithOutputPath on VideoFileManager'); }
+
+    let counter = 0;
+    [constants.DIR_NAMES.unprocessed_chunks, constants.DIR_NAMES.processed_chunks].forEach(dirName => {
+        [constants.DIR_NAMES.color, constants.DIR_NAMES.depth].forEach(colorOrDepth => {
+            getNestedFilePaths(deviceId, dirName, colorOrDepth).filter(path => {
+                return path.includes(sessionId);
+            }).map(filename => {
+                return path.join(outputPath, deviceId, dirName, colorOrDepth, filename);
+            }).forEach(chunkPath => {
+                fs.rmSync(chunkPath);
+                counter++;
+            });
+        });
+    });
+    if (counter > 0) {
+        console.log('deleted ' + counter + ' leftover video chunk files for recorded video ' + sessionId);
+    }
+};
+
+module.exports = {
+    initWithOutputPath: (path) => {
+        outputPath = path;
+        mkdirIfNeeded(path, true);
+    },
+    // we rebuild the json blob each time by parsing the filesystem, so this is stored mainly as a means for other systems to retrieve the data
+    buildPersistentInfo: () => {
+        if (!outputPath) { console.warn('You never called initWithOutputPath on VideoFileManager'); }
+
+        let info = {};
+        // each folder in outputPath is a device
+        // check that folder's session_videos, processed_chunks, and unprocessed_chunks to determine how many sessions there are and what state they're in
+        fs.readdirSync(outputPath).filter((filename) => {
+            let isHidden = filename[0] === '.';
+            return fs.statSync(path.join(outputPath, filename)).isDirectory() && !isHidden;
+        }).forEach(deviceDirName => {
+            info[deviceDirName] = parseDeviceDirectory(path.join(outputPath, deviceDirName));
+        });
+        persistentInfo = info;
+    },
+    savePersistentInfo: () => {
+        if (!outputPath) { console.warn('You never called initWithOutputPath on VideoFileManager'); }
+
+        let jsonPath = path.join(outputPath, 'videoInfo.json');
+        fs.writeFileSync(jsonPath, JSON.stringify(persistentInfo, null, 4));
+        console.log('saved recorded video metadata to ' + jsonPath);
+    },
+    getUnprocessedChunkFilePaths: (deviceId, colorOrDepth = constants.DIR_NAMES.color) => {
+        return getNestedFilePaths(deviceId, constants.DIR_NAMES.unprocessed_chunks, colorOrDepth);
+    },
+    getProcessedChunkFilePaths: (deviceId, colorOrDepth = constants.DIR_NAMES.color) => {
+        return getNestedFilePaths(deviceId, constants.DIR_NAMES.processed_chunks, colorOrDepth);
+    },
+    getSessionFilePaths: (deviceId, colorOrDepth = constants.DIR_NAMES.color) => {
+        return getNestedFilePaths(deviceId, constants.DIR_NAMES.session_videos, colorOrDepth);
+    },
+    deleteLeftoverChunks(deviceId) {
+        let colorSessionPaths = module.exports.getSessionFilePaths(deviceId, constants.DIR_NAMES.color);
+        let depthSessionPaths = module.exports.getSessionFilePaths(deviceId, constants.DIR_NAMES.depth);
+        colorSessionPaths.forEach(path => {
+            if (depthSessionPaths.includes(path)) {
+                let sessionId = getSessionIdFromFilename(path, 'session_');
+                deleteChunksForSession(deviceId, sessionId);
+            }
+        });
+    },
+    get outputPath() { return outputPath; },
+    get persistentInfo() { return persistentInfo; }
+};

--- a/interfaces/remoteOperatorUI/VideoFileManager.js
+++ b/interfaces/remoteOperatorUI/VideoFileManager.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const constants = require('./videoConstants');
+const ffmpegInterface = require('./ffmpegInterface');
 
 /**
  * @fileOverview
@@ -51,6 +52,13 @@ const parseDeviceDirectory = (devicePath) => {
                 info[sessionId] = {};
             }
             info[sessionId].color = filepath;
+
+            // print the duration of the color video
+            // console.log('get video duration: ' + path.join(sessionVideosPath, constants.DIR_NAMES.color, filepath));
+            ffmpegInterface.ffmpeg_get_duration(path.join(sessionVideosPath, constants.DIR_NAMES.color, filepath), (seconds) => {
+                console.log(filepath + ' is ' + seconds + ' seconds long');
+            });
+
             if (fs.existsSync(path.join(sessionVideosPath, constants.DIR_NAMES.depth, filepath))) {
                 info[sessionId].depth = filepath;
             }

--- a/interfaces/remoteOperatorUI/VideoFileManager.js
+++ b/interfaces/remoteOperatorUI/VideoFileManager.js
@@ -53,12 +53,6 @@ const parseDeviceDirectory = (devicePath) => {
             }
             info[sessionId].color = filepath;
 
-            // print the duration of the color video
-            // console.log('get video duration: ' + path.join(sessionVideosPath, constants.DIR_NAMES.color, filepath));
-            ffmpegInterface.ffmpeg_get_duration(path.join(sessionVideosPath, constants.DIR_NAMES.color, filepath), (seconds) => {
-                console.log(filepath + ' is ' + seconds + ' seconds long');
-            });
-
             if (fs.existsSync(path.join(sessionVideosPath, constants.DIR_NAMES.depth, filepath))) {
                 info[sessionId].depth = filepath;
             }

--- a/interfaces/remoteOperatorUI/VideoFileManager.js
+++ b/interfaces/remoteOperatorUI/VideoFileManager.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const constants = require('./videoConstants');
-const ffmpegInterface = require('./ffmpegInterface');
+const utils = require('./utilities');
 
 /**
  * @fileOverview
@@ -16,16 +16,8 @@ let persistentInfo = null;
 
 // Private functions not exposed to other modules
 
-const mkdirIfNeeded = (path, recursive) => { // helper function since we do this so often
-    let options = recursive ? {recursive: true} : undefined;
-    if (!fs.existsSync(path)) {
-        fs.mkdirSync(path, options);
-        console.log('VideoFileManager created directory: ' + path);
-    }
-};
-
 const createMissingDirs = (devicePath) => {
-    mkdirIfNeeded(devicePath);
+    utils.mkdirIfNeeded(devicePath);
     let dir = constants.DIR_NAMES;
 
     let sessionVideosPath = path.join(devicePath, dir.session_videos);
@@ -33,9 +25,9 @@ const createMissingDirs = (devicePath) => {
     let processedChunksPath = path.join(devicePath, dir.processed_chunks);
 
     [dir.color, dir.depth, dir.pose].forEach(name => {
-        mkdirIfNeeded(path.join(sessionVideosPath, name), true);
-        mkdirIfNeeded(path.join(unprocessedChunksPath, name), true);
-        mkdirIfNeeded(path.join(processedChunksPath, name), true);
+        utils.mkdirIfNeeded(path.join(sessionVideosPath, name), true);
+        utils.mkdirIfNeeded(path.join(unprocessedChunksPath, name), true);
+        utils.mkdirIfNeeded(path.join(processedChunksPath, name), true);
     });
 };
 
@@ -102,7 +94,7 @@ const getNestedFilePaths = (deviceId, dirName, colorOrDepth) => {
     if (!outputPath) { console.warn('You never called initWithOutputPath on VideoFileManager'); }
 
     let dirPath = path.join(outputPath, deviceId, dirName, colorOrDepth);
-    mkdirIfNeeded(dirPath, true);
+    utils.mkdirIfNeeded(dirPath, true);
     let filetype = '.' + ((colorOrDepth === constants.DIR_NAMES.depth) ? constants.DEPTH_FILETYPE : constants.COLOR_FILETYPE);
     return fs.readdirSync(dirPath).filter(filename => filename.includes(filetype));
 };
@@ -131,7 +123,7 @@ const deleteChunksForSession = (deviceId, sessionId) => {
 module.exports = {
     initWithOutputPath: (path) => {
         outputPath = path;
-        mkdirIfNeeded(path, true);
+        utils.mkdirIfNeeded(path, true);
     },
     // we rebuild the json blob each time by parsing the filesystem, so this is stored mainly as a means for other systems to retrieve the data
     buildPersistentInfo: () => {

--- a/interfaces/remoteOperatorUI/VideoProcessManager.js
+++ b/interfaces/remoteOperatorUI/VideoProcessManager.js
@@ -1,0 +1,219 @@
+const fs = require('fs');
+const path = require('path');
+const ffmpegInterface = require('./ffmpegInterface');
+const VideoFileManager = require('./VideoFileManager');
+const constants = require('./videoConstants');
+
+/**
+ * @fileOverview
+ * The VideoProcessManager listens for messages originating from virtualizer devices,
+ * and creates a new Connection to manage the raw video recording process for each camera device
+ * The Connection spawns a ffmpeg process when a startRecording message is received, and continuously
+ * appends frame data to this process until the device sends stopRecording or disconnects.
+ * Frame data is written to a new video "chunk" file each 15 seconds, to reduce memory footprint and point of failure.
+ * When the Connection's process is done, it triggers a callback where the VideoServer can make use of the chunk files.
+ */
+
+let connections = {};
+let callbacks = {
+    recordingDone: null
+};
+
+module.exports = {
+    onConnection: (deviceId) => {
+        console.log('-- on connection: ' + deviceId);
+        connections[deviceId] = new Connection(deviceId, callbacks);
+    },
+    onDisconnection: (deviceId) => {
+        console.log('-- on disconnection: ' + deviceId);
+        if (connections[deviceId]) {
+            connections[deviceId].stopRecording(true);
+            // TODO: should we also delete this.connections[deviceId]?
+        }
+    },
+    startRecording: (deviceId) => {
+        console.log('-- start recording: ' + deviceId);
+        if (connections[deviceId]) {
+            connections[deviceId].startRecording();
+        }
+    },
+    stopRecording: (deviceId) => {
+        console.log('-- stop recording: ' + deviceId);
+        if (connections[deviceId]) {
+            connections[deviceId].stopRecording(false);
+        }
+    },
+    onFrame: (rgb, depth, pose, deviceId) => {
+        if (connections[deviceId]) {
+            connections[deviceId].onFrame(rgb, depth, pose);
+        }
+    },
+    setRecordingDoneCallback: (callback) => {
+        callbacks.recordingDone = callback;
+    }
+};
+
+class Connection {
+    constructor(deviceId, callbacks) {
+        this.deviceId = deviceId;
+        this.sessionId = null;
+        this.STATUS = Object.freeze({
+            NOT_STARTED: 'NOT_STARTED',
+            STARTED: 'STARTED',
+            ENDING: 'ENDING',
+            DISCONNECTED: 'DISCONNECTED',
+            STOPPED: 'STOPPED'
+        });
+        this.isRecording = false;
+        this.processes = {
+            color: null,
+            depth: null,
+            pose: null
+        };
+        this.processStatuses = {
+            color: this.STATUS.NOT_STARTED,
+            depth: this.STATUS.NOT_STARTED,
+            pose: this.STATUS.NOT_STARTED
+        };
+        this.poses = [];
+        this.chunkCount = 0;
+        this.callbacks = callbacks;
+    }
+    startRecording() {
+        this.sessionId = this.uuidTimeShort();
+        this.chunkCount = 0;
+        this.isRecording = true;
+        // fileManager setup persistent data and directories
+
+        this.spawnProcesses();
+
+        // process data and restart every 15 seconds (unless socket disconnected, just process data and stop)
+        setTimeout(_ => {
+            this.stopProcesses();
+            if (this.processStatuses.color !== this.STATUS.DISCONNECTED &&
+                this.processStatuses.color !== this.STATUS.STOPPED) {
+                setTimeout(_ => {
+                    this.recordNextChunk();
+                }, 10); // not sure if this delay is necessary between chunks but doesnt seem unreasonable
+            }
+        }, constants.SEGMENT_LENGTH);
+    }
+    recordNextChunk() {
+        this.chunkCount += 1;
+        this.isRecording = true;
+
+        this.spawnProcesses();
+
+        // process data and restart every 15 seconds (unless socket disconnected, just process data and stop)
+        setTimeout(_ => {
+            this.stopProcesses();
+            if (this.processStatuses.color !== this.STATUS.DISCONNECTED &&
+                this.processStatuses.color !== this.STATUS.STOPPED) {
+                setTimeout(_ => {
+                    this.recordNextChunk();
+                }, 10);
+            }
+        }, constants.SEGMENT_LENGTH);
+    }
+    spawnProcesses() {
+        let index = this.chunkCount; // this.processChunkCounts[deviceId][sessionId];
+
+        // start color stream process
+        // depth images are 1920x1080 lossy JPG images
+        let chunkTimestamp = Date.now();
+        let colorFilename = 'chunk_' + this.sessionId + '_' + index + '_' + chunkTimestamp + '.' + constants.COLOR_FILETYPE;
+        let colorOutputPath = path.join(VideoFileManager.outputPath, this.deviceId, constants.DIR_NAMES.unprocessed_chunks, constants.DIR_NAMES.color, colorFilename);
+        this.processes.color = ffmpegInterface.ffmpeg_image2mp4(colorOutputPath, constants.RECORDING_FPS, 'mjpeg', 1920, 1080, constants.COLOR_CRF, constants.COLOR_SCALE);
+        if (this.processes.color) {
+            this.processStatuses.color = this.STATUS.STARTED;
+        }
+
+        // start depth stream process
+        // depth images are 256x144 lossless PNG buffers
+        let depthFilename = 'chunk_' + this.sessionId + '_' + index + '_' + chunkTimestamp + '.' + constants.DEPTH_FILETYPE;
+        let depthOutputPath = path.join(VideoFileManager.outputPath, this.deviceId, constants.DIR_NAMES.unprocessed_chunks, constants.DIR_NAMES.depth, depthFilename);
+        this.processes.depth = ffmpegInterface.ffmpeg_image2mp4(depthOutputPath, constants.RECORDING_FPS, 'png', 256, 144, constants.DEPTH_CRF, constants.DEPTH_SCALE);
+        // this.processes[deviceId][this.PROCESS.DEPTH] = ffmpeg_image2losslessVideo(depthOutputPath, 10, 'png', 256, 144); // this version isn't working as reliably
+        // this.processes[deviceId][this.PROCESS.DEPTH] = ffmpeg_image2mp4(depthOutputPath, 10, 'png', 256, 144, 0, 1);
+        if (this.processes.depth) {
+            this.processStatuses.depth = this.STATUS.STARTED;
+        }
+
+        this.processStatuses.pose = this.STATUS.STARTED;
+        this.poses = [];
+    }
+    onFrame(rgb, depth, pose) {
+        if (!this.isRecording) { return; }
+
+        if (this.processes.color && this.processStatuses.color === this.STATUS.STARTED) {
+            this.processes.color.stdin.write(rgb);
+        }
+        if (this.processes.depth && this.processStatuses.depth === this.STATUS.STARTED) {
+            this.processes.depth.stdin.write(depth);
+        }
+        if (this.processStatuses.pose === this.STATUS.STARTED) {
+            this.poses.push({
+                pose: pose.toString('base64'),
+                time: Date.now()
+            });
+        }
+        // TODO: include constants.DEBUG_WRITE_IMAGES code?
+    }
+    stopProcesses() {
+        this.isRecording = false;
+
+        if (this.processes.color !== 'undefined' && this.processStatuses.color === this.STATUS.STARTED) {
+            console.log('end color process');
+            this.processes.color.stdin.setEncoding('utf8');
+            this.processes.color.stdin.write('q');
+            this.processes.color.stdin.end();
+            this.processStatuses.color = this.STATUS.ENDING;
+        }
+
+        if (this.processes.depth !== 'undefined' && this.processStatuses.depth === this.STATUS.STARTED) {
+            console.log('end depth process');
+            this.processes.depth.stdin.setEncoding('utf8');
+            this.processes.depth.stdin.write('q');
+            this.processes.depth.stdin.end();
+            this.processStatuses.depth = this.STATUS.ENDING;
+
+            // TODO: should this move to the processStatuses.pose block?
+            let index = this.chunkCount;
+            let poseFilename = 'chunk_' + this.sessionId + '_' + index + '_' + Date.now() + '.json';
+            let poseOutputPath = path.join(VideoFileManager.outputPath, this.deviceId, constants.DIR_NAMES.unprocessed_chunks, 'pose', poseFilename);
+            fs.writeFileSync(poseOutputPath, JSON.stringify(this.poses));
+            this.poses = [];
+        }
+
+        if (this.processStatuses.pose === this.STATUS.STARTED) {
+            console.log('end pose process');
+            this.processStatuses.pose = this.STATUS.ENDING;
+        }
+    }
+    stopRecording(didDisconnect) {
+        if (this.isRecording) {
+            this.stopProcesses();
+        }
+        if (didDisconnect) {
+            this.processStatuses.color = this.STATUS.DISCONNECTED;
+            this.processStatuses.depth = this.STATUS.DISCONNECTED;
+            this.processStatuses.pose = this.STATUS.DISCONNECTED;
+        } else {
+            this.processStatuses.color = this.STATUS.STOPPED;
+            this.processStatuses.depth = this.STATUS.STOPPED;
+            this.processStatuses.pose = this.STATUS.STOPPED;
+        }
+
+        // when the video processes are done, other modules can do what they'd like with it
+        if (this.callbacks.recordingDone) {
+            this.callbacks.recordingDone(this.deviceId, this.sessionId, this.chunkCount);
+        }
+    }
+    uuidTimeShort() {
+        var dateUuidTime = new Date();
+        var abcUuidTime = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        var stampUuidTime = parseInt('' + dateUuidTime.getMilliseconds() + dateUuidTime.getMinutes() + dateUuidTime.getHours() + dateUuidTime.getDay()).toString(36);
+        while (stampUuidTime.length < 8) stampUuidTime = abcUuidTime.charAt(Math.floor(Math.random() * abcUuidTime.length)) + stampUuidTime;
+        return stampUuidTime;
+    }
+}

--- a/interfaces/remoteOperatorUI/VideoServer.js
+++ b/interfaces/remoteOperatorUI/VideoServer.js
@@ -4,6 +4,7 @@ const ffmpegInterface = require('./ffmpegInterface');
 const VideoFileManager = require('./VideoFileManager');
 const VideoProcessManager = require('./VideoProcessManager');
 const constants = require('./videoConstants');
+const utils = require('./utilities');
 
 /**
  * @fileOverview
@@ -72,9 +73,7 @@ class VideoServer {
     // TODO: this could be optimized by listening for files to finish writing, rather than waiting a fixed time
     onRecordingDone(deviceId, sessionId, lastChunkIndex) {
         setTimeout(() => { // wait for final video to finish processing
-            if (!fs.existsSync(path.join(this.outputPath, deviceId, 'tmp'))) {
-                fs.mkdirSync(path.join(this.outputPath, deviceId, 'tmp'));
-            }
+            utils.mkdirIfNeeded(path.join(this.outputPath, deviceId, 'tmp'));
             let tmpOutputPath = path.join(this.outputPath, deviceId, 'tmp', sessionId + '_done_' + lastChunkIndex + '.json');
             fs.writeFileSync(tmpOutputPath, JSON.stringify({ success: true}));
 
@@ -147,9 +146,7 @@ class VideoServer {
 
         // write file list to txt file so it can be used by ffmpeg as input
         let txt_filename = colorOrDepth + '_filenames_' + sessionId + '.txt';
-        if (!fs.existsSync(path.join(this.outputPath, deviceId, 'tmp'))) {
-            fs.mkdirSync(path.join(this.outputPath, deviceId, 'tmp'));
-        }
+        utils.mkdirIfNeeded(path.join(this.outputPath, deviceId, 'tmp'));
         let txtFilePath = path.join(this.outputPath, deviceId, 'tmp', txt_filename);
         if (fs.existsSync(txtFilePath)) {
             fs.unlinkSync(txtFilePath);

--- a/interfaces/remoteOperatorUI/VideoServer.js
+++ b/interfaces/remoteOperatorUI/VideoServer.js
@@ -1,0 +1,253 @@
+const fs = require('fs');
+const path = require('path');
+const ffmpegInterface = require('./ffmpegInterface');
+const VideoFileManager = require('./VideoFileManager');
+const VideoProcessManager = require('./VideoProcessManager');
+const constants = require('./videoConstants');
+
+/**
+ * @fileOverview
+ * The VideoServer handles logic to record point cloud videos captured by the streamRouter
+ * It passes messages to the VideoProcessManager (onConnection, onDisconnection, startRecording, stopRecording, onFrame)
+ * and it utilizes the VideoFileManager to save the recorded video chunks (and json poses) to a nested directory at the outputPath
+ *
+ * Recorded videos pass through three stages:
+ * 1. unprocessed_chunks: these are 15 second video segments created on a rolling basis while the video is recording
+ * 2. processed_chunks: when the video has stopped recording, chunks have an optional post-processing step and are copied here
+ * 3. session_videos: when all chunks have been processed, they are concatenated into a final video here
+ *
+ * RGB and depth videos are created with ffmpeg child processes. Parameters can be configured in videoConstants and ffmpegInterface.
+ * Poses are written to json files as a list of timestamped base64-encoded matrices.
+ *
+ * Metadata for all recordings can be accessed at localhost:8081/virtualizer_recordings
+ */
+class VideoServer {
+    constructor(outputPath) {
+        this.outputPath = outputPath;
+        console.log('Created a VideoServer with path: ' + this.outputPath);
+
+        VideoFileManager.initWithOutputPath(outputPath);
+        // we rebuild/save the persistentInfo on server restart so that it doesn't get out-of-sync with filesystem state
+        VideoFileManager.buildPersistentInfo();
+        VideoFileManager.savePersistentInfo();
+
+        // the process manager is mostly self-sufficient at creating the recordings, but we need to know when it's done.
+        // it records in 15 second chunks, and when it's done we concatenate the chunks together
+        VideoProcessManager.setRecordingDoneCallback(this.onRecordingDone.bind(this));
+
+        // each time the server restarts, we check for chunks that were never concatenated and try to concat them into finished videos
+        // this way, if the server unexpectedly stops while the videos are processing, they can be recovered
+        Object.keys(VideoFileManager.persistentInfo).forEach(deviceId => {
+            this.concatChunksIntoSessionVideo(deviceId);
+        });
+
+        // this copies over chunk files from unprocessed_chunks to processed_chunks
+        // processed_chunks is a way to future-proof the system such that if we want to do any post-processing of the
+        // chunk files, we have a place to reliably do that before making the videos available to the system in a concatenated form
+        // for example, we can rescale each chunk to a certain length or re-encode them based on info we have only after all the chunks have been recorded
+        Object.keys(VideoFileManager.persistentInfo).forEach(deviceId => {
+            this.processUnprocessedChunks(deviceId);
+        });
+
+        // after chunks have been concatenated into a session video, we can delete them
+        Object.keys(VideoFileManager.persistentInfo).forEach(deviceId => {
+            VideoFileManager.deleteLeftoverChunks(deviceId);
+        });
+    }
+    startRecording(deviceId) {
+        VideoProcessManager.startRecording(deviceId);
+    }
+    stopRecording(deviceId) {
+        VideoProcessManager.stopRecording(deviceId);
+    }
+    onConnection(deviceId) {
+        VideoProcessManager.onConnection(deviceId);
+    }
+    onDisconnection(deviceId) {
+        VideoProcessManager.onDisconnection(deviceId);
+    }
+    onFrame(rgb, depth, pose, deviceId) {
+        VideoProcessManager.onFrame(rgb, depth, pose, deviceId);
+    }
+    // TODO: this could be optimized by listening for files to finish writing, rather than waiting a fixed time
+    onRecordingDone(deviceId, sessionId, lastChunkIndex) {
+        setTimeout(() => { // wait for final video to finish processing
+            if (!fs.existsSync(path.join(this.outputPath, deviceId, 'tmp'))) {
+                fs.mkdirSync(path.join(this.outputPath, deviceId, 'tmp'));
+            }
+            let tmpOutputPath = path.join(this.outputPath, deviceId, 'tmp', sessionId + '_done_' + lastChunkIndex + '.json');
+            fs.writeFileSync(tmpOutputPath, JSON.stringify({ success: true}));
+
+            this.processUnprocessedChunks(deviceId);
+
+            // try concatenating after a longer delay. if not all chunks have finished processing by then...
+            // ...the chunk count won't match up and it will skip concatenating for now...
+            // ...it will reattempt each time you restart the server.
+            setTimeout(() => {
+                console.log('try to concat rescaled videos after waiting awhile after recording stopped');
+                VideoFileManager.buildPersistentInfo(); // recompile persistent info so session metadata contains new chunks
+                this.concatChunksIntoSessionVideo(deviceId);
+            }, 1000 * (lastChunkIndex + 1)); // delay 1 second per chunk we need to process, should give plenty of time
+        }, 5000);
+    }
+    concatChunksIntoSessionVideo(deviceId) {
+        if (!fs.existsSync(path.join(this.outputPath, deviceId))) {
+            console.log('concat, dir doesnt exist', path.join(this.outputPath, deviceId));
+            return;
+        }
+
+        // we use a tmp text file as a lock to ensure that all of the unprocessed chunks are represented in the processed chunks
+        let tmpFiles = [];
+        if (fs.existsSync(path.join(this.outputPath, deviceId, 'tmp'))) {
+            tmpFiles = fs.readdirSync(path.join(this.outputPath, deviceId, 'tmp'));
+        }
+
+        let sessions = VideoFileManager.persistentInfo[deviceId];
+        Object.keys(sessions).forEach(sessionId => {
+            let s = sessions[sessionId];
+            if (s.color && s.depth && s.pose) { return; }
+            if (s.processed_chunks && s.processed_chunks.length > 0) {
+                let matchingFiles = tmpFiles.filter(filename => { return filename.includes(sessionId + '_done'); });
+                let tmpFilename = matchingFiles.length > 0 ? matchingFiles[0] : null;
+                if (tmpFilename) {
+                    let numberOfChunks = parseInt(tmpFilename.match(/_\d+.json/)[0].match(/\d+/)[0]) + 1;
+                    console.log(deviceId + ':' + sessionId + ' should have ' + numberOfChunks + ' chunks');
+                    if (s.processed_chunks.length !== numberOfChunks && s.unprocessed_chunks.length === numberOfChunks) {
+                        console.log('there are some unprocessed chunks not present in the processed chunks', s.processed_chunks.length, s.unprocessed_chunks.length);
+                        return; // skip concatenating this session
+                    }
+                }
+
+                console.log('time to concatenate!');
+
+                if (!s.color) { s.color = this.concatFiles(deviceId, sessionId, constants.DIR_NAMES.color, s.processed_chunks); }
+                if (!s.depth) { s.depth = this.concatFiles(deviceId, sessionId, constants.DIR_NAMES.depth, s.processed_chunks); }
+                if (!s.pose) { s.pose = this.concatPosesIfNeeded(deviceId, sessionId); }
+            }
+        });
+
+        VideoFileManager.savePersistentInfo();
+    }
+    extractTimeInformation(fileList) { // TODO: we can probably just use the SEGMENT_LENGTH * fileList.length?
+        let fileRecordingTimes = fileList.map(filename => parseInt(filename.match(/[0-9]{13,}/))); // extract timestamp
+        let firstTimestamp = Math.min(...fileRecordingTimes) - constants.SEGMENT_LENGTH; // estimate, since this is at the end of the first video
+        let lastTimestamp = Math.max(...fileRecordingTimes);
+        return {
+            start: firstTimestamp,
+            end: lastTimestamp,
+            duration: lastTimestamp - firstTimestamp
+        };
+    }
+    concatFiles(deviceId, sessionId, colorOrDepth = constants.DIR_NAMES.color, files) {
+        // passing a list of videos into ffmpeg is most easily done with a txt file listing the files in a specific format
+        let fileText = '';
+        for (let i = 0; i < files.length; i++) {
+            fileText += 'file \'' + path.join(this.outputPath, deviceId, constants.DIR_NAMES.processed_chunks, colorOrDepth, files[i]) + '\'\n';
+        }
+
+        // write file list to txt file so it can be used by ffmpeg as input
+        let txt_filename = colorOrDepth + '_filenames_' + sessionId + '.txt';
+        if (!fs.existsSync(path.join(this.outputPath, deviceId, 'tmp'))) {
+            fs.mkdirSync(path.join(this.outputPath, deviceId, 'tmp'));
+        }
+        let txtFilePath = path.join(this.outputPath, deviceId, 'tmp', txt_filename);
+        if (fs.existsSync(txtFilePath)) {
+            fs.unlinkSync(txtFilePath);
+        }
+        fs.writeFileSync(txtFilePath, fileText);
+
+        let filetype = (colorOrDepth === constants.DIR_NAMES.depth) ? constants.DEPTH_FILETYPE : constants.COLOR_FILETYPE;
+        // we store the video timestamp directly in its filename, so this info never gets lost
+        let timeInfo = this.extractTimeInformation(files);
+        let filename = 'device_' + deviceId + '_session_' + sessionId + '_start_' + timeInfo.start + '_end_' + timeInfo.end + '.' + filetype;
+        let outputPath = path.join(this.outputPath, deviceId, constants.DIR_NAMES.session_videos, colorOrDepth, filename);
+        ffmpegInterface.ffmpeg_concat_mp4s(outputPath, txtFilePath);
+
+        return filename;
+    }
+    concatPosesIfNeeded(deviceId, sessionId) {
+        // check if output file exists for this device/session pair
+        let filename = 'device_' + deviceId + '_session_' + sessionId + '.json';
+        let outputPath = path.join(this.outputPath, deviceId, constants.DIR_NAMES.session_videos, 'pose', filename);
+        if (fs.existsSync(outputPath)) {
+            return filename; // already exists, return early
+        }
+        console.log('we still need to process poses for ' + deviceId + ' (session ' + sessionId + ')');
+
+        // load all pose chunks. each is a json file with a timestamped list of poses for 15 seconds of the video
+        let files = fs.readdirSync(path.join(this.outputPath, deviceId, constants.DIR_NAMES.unprocessed_chunks, 'pose'));
+        files = files.filter(filename => {
+            return filename.includes(sessionId);
+        });
+        console.log('unprocessed pose chunks: ', files);
+
+        // the concatenated file contains a correctly-ordered array with all of the poses from each chunk's array
+        let poseData = [];
+        files.forEach(filename => {
+            let filePath = path.join(this.outputPath, deviceId, constants.DIR_NAMES.unprocessed_chunks, 'pose', filename);
+            poseData.push(JSON.parse(fs.readFileSync(filePath, 'utf-8')));
+        });
+        let flattened = poseData.flat();
+        fs.writeFileSync(outputPath, JSON.stringify(flattened));
+
+        return filename;
+    }
+    processUnprocessedChunks(deviceId) {
+        let unprocessedPath = path.join(this.outputPath, deviceId, constants.DIR_NAMES.unprocessed_chunks);
+        let processedPath = path.join(this.outputPath, deviceId, constants.DIR_NAMES.processed_chunks);
+        let fileMap = {
+            color: {
+                processed: VideoFileManager.getProcessedChunkFilePaths(deviceId, constants.DIR_NAMES.color),
+                unprocessed: VideoFileManager.getUnprocessedChunkFilePaths(deviceId, constants.DIR_NAMES.color)
+            },
+            depth: {
+                processed: VideoFileManager.getProcessedChunkFilePaths(deviceId, constants.DIR_NAMES.depth),
+                unprocessed: VideoFileManager.getUnprocessedChunkFilePaths(deviceId, constants.DIR_NAMES.depth)
+            }
+        };
+
+        Object.keys(fileMap).forEach(colorOrDepth => {
+            let filesToScale = [];
+
+            // ignore any video chunks that are corrupted (~0 bytes), perhaps due to stopping recording before it wrote any frames
+            fileMap[colorOrDepth].unprocessed.forEach(filename => {
+                let timestamp = filename.match(/[0-9]{13,}/);
+                if (!fileMap[colorOrDepth].processed.some(resizedFilename => resizedFilename.includes(timestamp))) {
+                    let colorFilename = filename.replace(/\.[^/.]+$/, '') + '.' + constants.COLOR_FILETYPE;
+                    let depthFilename = filename.replace(/\.[^/.]+$/, '') + '.' + constants.DEPTH_FILETYPE;
+                    let colorFilePath = path.join(unprocessedPath, constants.DIR_NAMES.color, colorFilename);
+                    let depthFilePath = path.join(unprocessedPath, constants.DIR_NAMES.depth, depthFilename);
+                    if (fs.existsSync(colorFilePath) && fs.existsSync(depthFilePath)) {
+                        let byteSizeColor = fs.statSync(colorFilePath).size;
+                        let byteSizeDepth = fs.statSync(depthFilePath).size;
+                        if (byteSizeColor > 48 && byteSizeDepth > 48) {
+                            filesToScale.push(filename);
+                        } else {
+                            console.log('skipping ' + filename + ' due to incomplete size');
+                        }
+                    }
+                }
+            });
+
+            // note: why is ffmpeg_adjust_length part of the process? (sometimes?)
+            // the incoming image stream, while it approximates 10 fps, is not exactly that.
+            // so the resulting "15 second" chunks are sometimes 8 seconds, sometimes 10, etc.
+            // one way to fix this time warping is to rescale each chunk to be 15 seconds exactly.
+            // the other method (currently used) is to leave the chunks as-is, and correct it in the video playback system:
+            // use the timestamps stored in the filename, rather than the length of the video, during playback
+
+            // either copy the files directly to processed_chunks, or do some postprocessing (like ffmpeg_adjust_length)
+            filesToScale.forEach(filename => {
+                let inputPath = path.join(unprocessedPath, colorOrDepth, filename);
+                let outputPath = path.join(processedPath, colorOrDepth, filename);
+                if (constants.RESCALE_VIDEOS) {
+                    ffmpegInterface.ffmpeg_adjust_length(outputPath, inputPath, constants.SEGMENT_LENGTH / 1000);
+                } else {
+                    fs.copyFileSync(inputPath, outputPath, fs.constants.COPYFILE_EXCL);
+                }
+            });
+        });
+    }
+}
+
+module.exports = VideoServer;

--- a/interfaces/remoteOperatorUI/VideoServer.js
+++ b/interfaces/remoteOperatorUI/VideoServer.js
@@ -128,7 +128,7 @@ class VideoServer {
 
         VideoFileManager.savePersistentInfo();
     }
-    extractTimeInformation(fileList) { // TODO: we can probably just use the SEGMENT_LENGTH * fileList.length?
+    extractTimeInformation(fileList) { // we could also probably just use the SEGMENT_LENGTH * fileList.length, but this works too
         let fileRecordingTimes = fileList.map(filename => parseInt(filename.match(/[0-9]{13,}/))); // extract timestamp
         let firstTimestamp = Math.min(...fileRecordingTimes) - constants.SEGMENT_LENGTH; // estimate, since this is at the end of the first video
         let lastTimestamp = Math.max(...fileRecordingTimes);
@@ -229,7 +229,7 @@ class VideoServer {
                 }
             });
 
-            // note: why is ffmpeg_adjust_length part of the process? (sometimes?)
+            // note: why is ffmpeg_adjust_length (sometimes) part of the process:
             // the incoming image stream, while it approximates 10 fps, is not exactly that.
             // so the resulting "15 second" chunks are sometimes 8 seconds, sometimes 10, etc.
             // one way to fix this time warping is to rescale each chunk to be 15 seconds exactly.

--- a/interfaces/remoteOperatorUI/VideoServer.js
+++ b/interfaces/remoteOperatorUI/VideoServer.js
@@ -56,6 +56,7 @@ class VideoServer {
         });
     }
     startRecording(deviceId) {
+        VideoFileManager.createMissingDirs(path.join(this.outputPath, deviceId));
         VideoProcessManager.startRecording(deviceId);
     }
     stopRecording(deviceId) {

--- a/interfaces/remoteOperatorUI/ffmpegInterface.js
+++ b/interfaces/remoteOperatorUI/ffmpegInterface.js
@@ -47,8 +47,9 @@ module.exports = {
             //     console.log('stdout data', data);
             // });
             process.stderr.setEncoding('utf8');
-            process.stderr.on('data', function(data) {
+            process.stderr.on('data', function(data, err) {
                 console.log('stderr data', data);
+                console.warn(err);
             });
             // process.on('close', function() {
             //     console.log('finished');

--- a/interfaces/remoteOperatorUI/ffmpegInterface.js
+++ b/interfaces/remoteOperatorUI/ffmpegInterface.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const cp = require('child_process');
-const ffmpeg = require('@ffmpeg-installer/ffmpeg');
 const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
 const constants = require('./videoConstants');
 

--- a/interfaces/remoteOperatorUI/ffmpegInterface.js
+++ b/interfaces/remoteOperatorUI/ffmpegInterface.js
@@ -1,0 +1,192 @@
+const fs = require('fs');
+const cp = require('child_process');
+const ffmpeg = require('@ffmpeg-installer/ffmpeg');
+const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
+const constants = require('./videoConstants');
+
+/**
+ * @fileOverview
+ * This contains a set of utility functions that will spawn an ffmpeg child process to perform the specified task
+ * Enable constants.DEBUG_LOG_FFMPEG to print information from these processes
+ *
+ * Note: I've intentionally left the rubble of some experiments in here, that it may help future thought processes
+ *
+ * TODO: how can we listen for when the process finishes writing the output file, to reliably continue only when safe?
+ */
+
+module.exports = {
+    // Create a process that converts a stream of jpeg or png images into a video.
+    // To add a frame, call process.stdin.write(rgb_buffer). To finish, call process.stdin.end()
+    ffmpeg_image2mp4: (output_path, framerate = 10, input_vcodec = 'mjpeg', input_width = 1920, input_height = 1080, crf = 25, output_scale = 0.25) => {
+        let outputWidth = input_width * output_scale;
+        let outputHeight = input_height * output_scale;
+
+        let args = [
+            '-r', framerate,
+            // '-framerate', framerate,
+            // '-probesize', '5000',
+            // '-analyzeduration', '5000',
+            '-f', 'image2pipe',
+            '-vcodec', input_vcodec,
+            '-s', input_width + 'x' + input_height,
+            '-i', '-',
+            '-vcodec', 'libx264',
+            '-crf', crf,
+            '-pix_fmt', 'yuv420p',
+            '-vf', 'scale=' + outputWidth + ':' + outputHeight + ', setsar=1:1', //, realtime, fps=' + framerate,
+            // '-preset', 'ultrafast',
+            // '-copyts',
+            // '-tune', 'zerolatency',
+            // '-r', framerate, // will duplicate frames to meet this but still look like the framerate set before -i,
+            output_path
+        ];
+
+        let process = cp.spawn(ffmpegPath, args);
+
+        if (constants.DEBUG_LOG_FFMPEG) {
+            // process.stdout.on('data', function(data) {
+            //     console.log('stdout data', data);
+            // });
+            process.stderr.setEncoding('utf8');
+            process.stderr.on('data', function(data) {
+                console.log('stderr data', data);
+            });
+            // process.on('close', function() {
+            //     console.log('finished');
+            // });
+        }
+
+        return process;
+    },
+    // experimental alternative to ffmpeg_image2mp4 that tries to use lossless codecs and parameters
+    // not quite successful, but could be iterated upon
+    ffmpeg_image2losslessVideo: (output_path, framerate = 10, input_vcodec = 'png', input_width = 256, input_height = 144) => {
+        // let outputWidth = input_width;
+        // let outputHeight = input_height;
+
+        // ffmpeg -i video.avi -c:v libx265 \
+        //         -x265-params "profile=monochrome12:crf=0:lossless=1:preset=veryslow:qp=0" \
+        //         video.mkv
+
+        let args = [
+            '-r', framerate,
+            '-f', 'image2pipe',
+            '-vcodec', input_vcodec,
+            '-pix_fmt', 'argb',
+            '-s', input_width + 'x' + input_height,
+            '-i', '-',
+            // '-vcodec', 'libx265',
+            '-vcodec', 'libvpx-vp9',
+            '-lossless', '1',
+            // '-x265-params', 'lossless=1',
+            // '-pix_fmt', 'yuv420p',
+            '-pix_fmt', 'argb',
+            // '-vf', 'scale=' + outputWidth + ':' + outputHeight + ', setsar=1:1', //, realtime, fps=' + framerate,
+            // '-preset', 'ultrafast',
+            // '-copyts',
+            // '-tune', 'zerolatency',
+            // '-r', framerate, // will duplicate frames to meet this but still look like the framerate set before -i,
+            output_path
+        ];
+
+        // not working with MP4 ... works losslessly with .MKV but not playable in HTML video element
+        // let args = [
+        //     '-r', framerate,
+        //     '-f', 'image2pipe',
+        //     '-vcodec', input_vcodec,
+        //     '-s', input_width + 'x' + input_height,
+        //     '-i', '-',
+        //     '-vcodec', 'libx265',
+        //     '-x265-params', 'crf=0:lossless=1:preset=veryslow:qp=0',
+        //     // '-pix_fmt', 'yuv420p',
+        //     // '-vf', 'scale=' + outputWidth + ':' + outputHeight + ', setsar=1:1', //, realtime, fps=' + framerate,
+        //     // '-preset', 'ultrafast',
+        //     // '-copyts',
+        //     // '-tune', 'zerolatency',
+        //     // '-r', framerate, // will duplicate frames to meet this but still look like the framerate set before -i,
+        //     output_path
+        // ];
+
+        let process = cp.spawn(ffmpegPath, args);
+
+        if (constants.DEBUG_LOG_FFMPEG) {
+            // process.stdout.on('data', function(data) {
+            //     console.log('stdout data', data);
+            // });
+            process.stderr.setEncoding('utf8');
+            process.stderr.on('data', function (data) {
+                console.log('stderr data', data);
+            });
+            // process.on('close', function() {
+            //     console.log('finished');
+            // });
+        }
+
+        return process;
+    },
+    // takes in a textfile with a list of filepaths, one per line, e.g:
+    //      file '/my/file/path1.mp4'
+    //      file '/my/file/path2.mp4'
+    // and concatenates the specified video segments into a single video
+    ffmpeg_concat_mp4s: (output_path, file_list_path) => {
+        // ffmpeg -f concat -safe 0 -i fileList.txt -c copy mergedVideo.mp4
+        // we pass in a timestamp so we can use an identical one in the color and depth videos that match up
+        let args = [
+            '-f', 'concat',
+            '-safe', '0',
+            '-i', file_list_path,
+            '-c', 'copy',
+            output_path
+        ];
+
+        let process = cp.spawn(ffmpegPath, args);
+        return process;
+    },
+    // takes a video and resamples the timestamps of each frame to make it last the specified duration (in seconds)
+    // currently relying on the VideoLib.MovieParser to get the length of the video file, which is a bit flaky,
+    // as such this method isn't currently used and the VideoLib is commented out to avoid installing that dependency
+    // (https://www.npmjs.com/package/node-video-lib)
+    ffmpeg_adjust_length: (output_path, input_path, newDuration) => {
+        let filesize = fs.statSync(input_path);
+        console.log(filesize.size + ' bytes');
+        if (filesize.size <= 48) {
+            console.warn('corrupted video has ~0 bytes, cant resize: ' + input_path);
+            return;
+        }
+        fs.open(input_path, 'r', function(err, fd) {
+            try {
+                // let movie = VideoLib.MovieParser.parse(fd);
+                // Work with movie
+                // console.log('Duration:', movie.relativeDuration());
+
+                // getVideoDurationInSeconds(input_path).then((duration) => {
+                // console.log('old duration = ' + duration);
+
+                let movieDuration = 10;
+
+                console.log('change duration:', output_path, input_path, newDuration);
+                let args = [
+                    // '-f', filetype,
+                    '-i', input_path,
+                    '-filter:v', 'setpts=' + newDuration / movieDuration /*movie.relativeDuration()*/ + '*PTS',
+                    output_path
+                ];
+                let process = cp.spawn(ffmpegPath, args);
+
+                if (constants.DEBUG_LOG_FFMPEG) {
+                    process.stderr.setEncoding('utf8');
+                    process.stderr.on('data', function (data) {
+                        console.log('stderr data', data);
+                    });
+                }
+                console.log('new file: ' + output_path);
+                return output_path;
+                // });
+            } catch (ex) {
+                console.error('Video Error: ' + input_path, ex);
+            } finally {
+                fs.closeSync(fd);
+            }
+        }.bind(this));
+    }
+};

--- a/interfaces/remoteOperatorUI/index.js
+++ b/interfaces/remoteOperatorUI/index.js
@@ -80,7 +80,7 @@ function startHTTPServer(localUIApp, port) {
     const http = require('http').Server(localUIApp.app);
     const io = require('socket.io')(http);
 
-    const objectsPath = path.join(os.homedir(), 'Documents', 'spatialToolbox');
+    const objectsPath = server.getObjectsPath();
     const identityFolderName = '.identity';
 
     http.listen(port, function() {

--- a/interfaces/remoteOperatorUI/index.js
+++ b/interfaces/remoteOperatorUI/index.js
@@ -12,6 +12,7 @@
 
 const os = require('os');
 const path = require('path');
+const fs = require('fs');
 
 const server = require('@libraries/hardwareInterfaces');
 const utilities = require('@libraries/utilities');
@@ -79,8 +80,82 @@ function startHTTPServer(localUIApp, port) {
     const http = require('http').Server(localUIApp.app);
     const io = require('socket.io')(http);
 
+    const objectsPath = path.join(os.homedir(), 'Documents', 'spatialToolbox');
+    const identityFolderName = '.identity';
+
     http.listen(port, function() {
         console.log('~~~ started remote operator on port ' + port);
+
+        localUIApp.app.use('/virtualizer_recording/:deviceId/pose/:filename', function (req, res) {
+            let deviceId = req.params.deviceId;
+            let filename = req.params.filename;
+
+            const jsonFilePath = path.join(objectsPath, identityFolderName, 'virtualizer_recordings', deviceId, 'session_videos', 'pose', filename);
+
+            if (!fs.existsSync(jsonFilePath)) {
+                res.status(404).send('No file at path: ' + jsonFilePath);
+                return;
+            }
+
+            res.sendFile(jsonFilePath);
+        });
+
+        localUIApp.app.use('/virtualizer_recording/:deviceId/:colorOrDepth/:filename', function (req, res) {
+            let deviceId = req.params.deviceId;
+            let videoType = req.params.colorOrDepth;
+            let filename = req.params.filename;
+            const videoPath = path.join(objectsPath, identityFolderName, 'virtualizer_recordings', deviceId, 'session_videos', videoType, filename);
+
+            if (!fs.existsSync(videoPath)) {
+                res.status(404).send('No video at path: ' + videoPath);
+                return;
+            }
+
+            const range = req.headers.range;
+            if (!range) {
+                // res.status(400).send('Requires Range header');
+                res.sendFile(videoPath);
+                return;
+            }
+
+            const videoSize = fs.statSync(videoPath).size;
+            // console.log('Video Size = ' + Math.round(videoSize / 1000)  + 'kb');
+
+            // Parse Range (example: "bytes=32324-")
+            const CHUNK_SIZE = 10 ** 6; // 1 MB
+            const start = Number(range.replace(/\D/g, ''));
+            const end = Math.min(start + CHUNK_SIZE, videoSize - 1);
+
+            // Create Headers
+            const contentLength = end - start + 1;
+            const headers = {
+                'Content-Range': `bytes ${start}-${end}/${videoSize}`,
+                'Accept-Ranges': 'bytes',
+                'Content-Length': contentLength,
+                'Content-Type': 'video/mp4',
+            };
+
+            // HTTP Status 206 for partial content
+            res.writeHead(206, headers);
+            const videoStream = fs.createReadStream(videoPath, {start, end});
+            videoStream.pipe(res);
+        });
+
+        localUIApp.app.use('/virtualizer_recordings', function (req, res) {
+            const jsonPath = path.join(objectsPath, identityFolderName, 'virtualizer_recordings', 'videoInfo.json');
+
+            let defaultInfo = {
+                mergedFiles: {
+                    color: {},
+                    depth: {}
+                }
+            };
+            if (!fs.existsSync(jsonPath)) {
+                res.json(defaultInfo);
+            } else {
+                res.json(JSON.parse(fs.readFileSync(jsonPath, { encoding: 'utf8', flag: 'r' })));
+            }
+        });
 
         // pass visibleObjects messages to the userinterface
         server.subscribeToMatrixStream(function(visibleObjects) {

--- a/interfaces/remoteOperatorUI/makeStreamRouter.js
+++ b/interfaces/remoteOperatorUI/makeStreamRouter.js
@@ -16,6 +16,14 @@ module.exports = function makeStreamRouter(app) {
     let colorPool = [];
     let depthPool = [];
     let matrixPool = [];
+    let callbacks = {
+        onFrame: [],
+        onStartRecording: [],
+        onStopRecording: [],
+        onConnection: [],
+        onDisconnection: [],
+        onError: []
+    };
     app.ws('/colorProvider', function(ws, req) {
         console.log('new colorPro ws');
         const id = requestId(req);
@@ -27,6 +35,23 @@ module.exports = function makeStreamRouter(app) {
                 }
                 ws.send(msgWithId);
             }
+            processFrame(id, msg, null, null);
+        });
+        ws.on('close', function(event) {
+            console.log('ws.onclose ', event, id);
+            callbacks.onDisconnection.forEach(function(cb) {
+                cb(id);
+            });
+        });
+        ws.on('error', function(event) {
+            console.log('ws.onerror', event, id);
+            callbacks.onError.forEach(function(cb) {
+                cb(id);
+            });
+        });
+
+        callbacks.onConnection.forEach(function(cb) {
+            cb(id);
         });
     });
 
@@ -41,6 +66,7 @@ module.exports = function makeStreamRouter(app) {
                 }
                 ws.send(msgWithId);
             }
+            processFrame(id, null, msg, null);
         });
     });
 
@@ -79,6 +105,7 @@ module.exports = function makeStreamRouter(app) {
             for (const ws of matrixPool) {
                 ws.send(msgWithId);
             }
+            processFrame(id, null, null, msg);
         });
     });
 
@@ -97,7 +124,82 @@ module.exports = function makeStreamRouter(app) {
         matrixPool.push(ws);
     });
 
+    app.ws('/commands', function(ws, req) {
+        const id = requestId(req);
+        ws.on('message', function(msg, _isBinary) {
+            if (msg === 'startRecording') {
+                console.log('start recording (command) ' + id);
+                callbacks.onStartRecording.forEach(function(cb) {
+                    cb(id);
+                });
+            } else if (msg === 'stopRecording') {
+                console.log('stop recording (command) ' + id);
+                callbacks.onStopRecording.forEach(function(cb) {
+                    cb(id);
+                });
+            }
+        });
+    });
+
+    let frameData = {};
+    function processFrame(id, color, depth, matrix) {
+        if (typeof frameData[id] === 'undefined') {
+            frameData[id] = {
+                color: null,
+                depth: null,
+                matrix: null
+            };
+            return;
+        }
+        if (color) {
+            frameData[id].color = color;
+        }
+        if (depth) {
+            frameData[id].depth = depth;
+        }
+        if (matrix) {
+            frameData[id].matrix = matrix;
+        }
+        if (frameData[id].color && frameData[id].depth && frameData[id].matrix) {
+            // console.log('have color, depth, and matrix for id: ' + id);
+            callbacks.onFrame.forEach(function(cb) {
+                cb(frameData[id].color, frameData[id].depth, frameData[id].matrix, id);
+            });
+            delete frameData[id];
+        }
+    }
+
+    const onFrame = function(callback) {
+        callbacks.onFrame.push(callback);
+    };
+
+    const onStartRecording = function(callback) {
+        callbacks.onStartRecording.push(callback);
+    };
+
+    const onStopRecording = function(callback) {
+        callbacks.onStopRecording.push(callback);
+    };
+
+    const onConnection = function(callback) {
+        callbacks.onConnection.push(callback);
+    };
+
+    const onDisconnection = function(callback) {
+        callbacks.onDisconnection.push(callback);
+    };
+
+    const onError = function(callback) {
+        callbacks.onError.push(callback);
+    };
+
     return {
+        onFrame: onFrame,
+        onStartRecording: onStartRecording,
+        onStopRecording: onStopRecording,
+        onConnection: onConnection,
+        onDisconnection: onDisconnection,
+        onError: onError
     };
 };
 

--- a/interfaces/remoteOperatorUI/makeStreamRouter.js
+++ b/interfaces/remoteOperatorUI/makeStreamRouter.js
@@ -37,14 +37,12 @@ module.exports = function makeStreamRouter(app) {
             }
             processFrame(id, msg, null, null);
         });
-        ws.on('close', function(event) {
-            console.log('ws.onclose ', event, id);
+        ws.on('close', function(_event) {
             callbacks.onDisconnection.forEach(function(cb) {
                 cb(id);
             });
         });
-        ws.on('error', function(event) {
-            console.log('ws.onerror', event, id);
+        ws.on('error', function(_event) {
             callbacks.onError.forEach(function(cb) {
                 cb(id);
             });

--- a/interfaces/remoteOperatorUI/server.js
+++ b/interfaces/remoteOperatorUI/server.js
@@ -5,13 +5,13 @@ const makeStreamRouter = require('./makeStreamRouter.js');
 const VideoServer = require('./VideoServer.js');
 const path = require('path');
 const os = require('os');
+const server = require('@libraries/hardwareInterfaces');
 
 const DEBUG_DISABLE_VIDEO_RECORDING = false;
 
 module.exports.start = function start() {
     const app = express();
 
-    const objectsPath = path.join(os.homedir(), 'Documents', 'spatialToolbox');
     const identityFolderName = '.identity';
 
     app.use(cors());
@@ -20,7 +20,7 @@ module.exports.start = function start() {
 
     if (!DEBUG_DISABLE_VIDEO_RECORDING) {
         // rgb+depth videos are stored in the Documents/spatialToolbox/.identity/virtualizer_recordings
-        const videoServer = new VideoServer(path.join(objectsPath, identityFolderName, '/virtualizer_recordings'));
+        const videoServer = new VideoServer(path.join(server.getObjectsPath(), identityFolderName, '/virtualizer_recordings'));
         const DEVICE_ID_PREFIX = 'device';
 
         // trigger events in VideoServer whenever sockets connect, disconnect, or send data

--- a/interfaces/remoteOperatorUI/server.js
+++ b/interfaces/remoteOperatorUI/server.js
@@ -21,26 +21,27 @@ module.exports.start = function start() {
     if (!DEBUG_DISABLE_VIDEO_RECORDING) {
         // rgb+depth videos are stored in the Documents/spatialToolbox/.identity/virtualizer_recordings
         const videoServer = new VideoServer(path.join(objectsPath, identityFolderName, '/virtualizer_recordings'));
+        const DEVICE_ID_PREFIX = 'device';
 
         // trigger events in VideoServer whenever sockets connect, disconnect, or send data
         streamRouter.onFrame((rgb, depth, pose, deviceId) => {
-            videoServer.onFrame(rgb, depth, pose, 'device_' + deviceId); // TODO: remove device_ from name?
+            videoServer.onFrame(rgb, depth, pose, DEVICE_ID_PREFIX + deviceId);
         });
         streamRouter.onStartRecording((deviceId) => {
-            videoServer.startRecording('device_' + deviceId);
+            videoServer.startRecording(DEVICE_ID_PREFIX + deviceId);
         });
         streamRouter.onStopRecording((deviceId) => {
-            videoServer.stopRecording('device_' + deviceId);
+            videoServer.stopRecording(DEVICE_ID_PREFIX + deviceId);
         });
         streamRouter.onConnection((deviceId) => {
-            videoServer.onConnection('device_' + deviceId);
+            videoServer.onConnection(DEVICE_ID_PREFIX + deviceId);
         });
         streamRouter.onDisconnection((deviceId) => {
-            videoServer.onDisconnection('device_' + deviceId);
+            videoServer.onDisconnection(DEVICE_ID_PREFIX + deviceId);
         });
         streamRouter.onError((deviceId) => {
             console.log('on error: ' + deviceId); // haven't seen this trigger yet but probably good to also disconnect
-            videoServer.onDisconnection('device_' + deviceId);
+            videoServer.onDisconnection(DEVICE_ID_PREFIX + deviceId);
         });
     }
 

--- a/interfaces/remoteOperatorUI/utilities.js
+++ b/interfaces/remoteOperatorUI/utilities.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+module.exports = {
+    mkdirIfNeeded: (path, recursive) => { // helper function since we do this so often
+        let options = recursive ? {recursive: true} : undefined;
+        if (!fs.existsSync(path)) {
+            fs.mkdirSync(path, options);
+            console.log('created directory: ' + path);
+        }
+    }
+};

--- a/interfaces/remoteOperatorUI/videoConstants.js
+++ b/interfaces/remoteOperatorUI/videoConstants.js
@@ -1,0 +1,33 @@
+module.exports = Object.freeze({
+    // how long should each video chunk be (ms). they are concatenated when recording stops.
+    SEGMENT_LENGTH: 15000,
+    // note: if we change this here, also need to change timeline playback,
+    // because pose/image synchronization implementation depends on the FPS to locate the correct frame
+    RECORDING_FPS: 10,
+
+    // files are stored in the outputPath (currently Documents/spatialToolbox/.identity/virtualizer_recordings)
+    // an example filepath looks something like virtualizer_recordings/deviceId/session_videos/color/filename.mp4
+    DIR_NAMES: {
+        unprocessed_chunks: 'unprocessed_chunks', // where to store raw 15 second recording chunks
+        processed_chunks: 'processed_chunks', // where to store chunks after optional post-processing
+        session_videos: 'session_videos', // where to store concatenated chunks as a final video
+        color: 'color', // subdirectory for rgb video files
+        depth: 'depth', // subdirectory for depth video files
+        pose: 'pose' // subdirectory for pose json files
+    },
+
+    // adjustable ffmpeg parameters
+    COLOR_FILETYPE: 'mp4',
+    DEPTH_FILETYPE: 'mp4', // previously tried webm and mkv for lossless encoding but it never quite worked
+    COLOR_CRF: 25, // 0 is pseudo-lossless, 51 is worst quality possible, 23 is considered default
+    DEPTH_CRF: 13, // a subjectively sane range for crf is 17-28 (https://trac.ffmpeg.org/)
+    COLOR_SCALE: 0.5, // camera image is 1920x1080, this will scale down the video dimensions
+    DEPTH_SCALE: 1, // depth sensor image is 256x144. should probably stay at scale=1 to preserve information.
+
+    // disable to prevent lossy transformation, enable to stretch videos back to correct time length
+    // (it's ok to be false, the video playback system can adjust for this)
+    RESCALE_VIDEOS: false,
+    // write each color and depth frame to an image file while recording, useful for debugging if ffmpeg isn't working
+    DEBUG_WRITE_IMAGES: false,
+    DEBUG_LOG_FFMPEG: false
+});

--- a/interfaces/remoteOperatorUI/videoConstants.js
+++ b/interfaces/remoteOperatorUI/videoConstants.js
@@ -27,7 +27,5 @@ module.exports = Object.freeze({
     // disable to prevent lossy transformation, enable to stretch videos back to correct time length
     // (it's ok to be false, the video playback system can adjust for this)
     RESCALE_VIDEOS: false,
-    // write each color and depth frame to an image file while recording, useful for debugging if ffmpeg isn't working
-    DEBUG_WRITE_IMAGES: false,
     DEBUG_LOG_FFMPEG: false
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,133 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "vuforia-spatial-remote-operator-addon",
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "cors": "^2.8.5",
         "express": "^4.17.1",
         "express-ws": "^5.0.2",
         "socket.io": "~2.2.0",
         "socket.io-client": "~2.3.1"
       }
+    },
+    "node_modules/@ffmpeg-installer/darwin-arm64": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-arm64/-/darwin-arm64-4.1.5.tgz",
+      "integrity": "sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/darwin-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
+      "integrity": "sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/ffmpeg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz",
+      "integrity": "sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==",
+      "optionalDependencies": {
+        "@ffmpeg-installer/darwin-arm64": "4.1.5",
+        "@ffmpeg-installer/darwin-x64": "4.1.0",
+        "@ffmpeg-installer/linux-arm": "4.1.3",
+        "@ffmpeg-installer/linux-arm64": "4.1.4",
+        "@ffmpeg-installer/linux-ia32": "4.1.0",
+        "@ffmpeg-installer/linux-x64": "4.1.0",
+        "@ffmpeg-installer/win32-ia32": "4.1.0",
+        "@ffmpeg-installer/win32-x64": "4.1.0"
+      }
+    },
+    "node_modules/@ffmpeg-installer/linux-arm": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz",
+      "integrity": "sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==",
+      "cpu": [
+        "arm"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-arm64": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz",
+      "integrity": "sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
+      "integrity": "sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz",
+      "integrity": "sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/win32-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
+      "integrity": "sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/win32-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz",
+      "integrity": "sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -986,6 +1103,69 @@
     }
   },
   "dependencies": {
+    "@ffmpeg-installer/darwin-arm64": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-arm64/-/darwin-arm64-4.1.5.tgz",
+      "integrity": "sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==",
+      "optional": true
+    },
+    "@ffmpeg-installer/darwin-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
+      "integrity": "sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==",
+      "optional": true
+    },
+    "@ffmpeg-installer/ffmpeg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz",
+      "integrity": "sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==",
+      "requires": {
+        "@ffmpeg-installer/darwin-arm64": "4.1.5",
+        "@ffmpeg-installer/darwin-x64": "4.1.0",
+        "@ffmpeg-installer/linux-arm": "4.1.3",
+        "@ffmpeg-installer/linux-arm64": "4.1.4",
+        "@ffmpeg-installer/linux-ia32": "4.1.0",
+        "@ffmpeg-installer/linux-x64": "4.1.0",
+        "@ffmpeg-installer/win32-ia32": "4.1.0",
+        "@ffmpeg-installer/win32-x64": "4.1.0"
+      }
+    },
+    "@ffmpeg-installer/linux-arm": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz",
+      "integrity": "sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==",
+      "optional": true
+    },
+    "@ffmpeg-installer/linux-arm64": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz",
+      "integrity": "sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==",
+      "optional": true
+    },
+    "@ffmpeg-installer/linux-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
+      "integrity": "sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==",
+      "optional": true
+    },
+    "@ffmpeg-installer/linux-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz",
+      "integrity": "sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==",
+      "optional": true
+    },
+    "@ffmpeg-installer/win32-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
+      "integrity": "sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==",
+      "optional": true
+    },
+    "@ffmpeg-installer/win32-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz",
+      "integrity": "sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==",
+      "optional": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "homepage": "https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon#readme",
   "dependencies": {
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-ws": "^5.0.2",


### PR DESCRIPTION
Updates the remoteOperatorUI interface so that the streamRouter additionally sends rgb+depth+pose data to a VideoServer class, which is composed of a few different modules that process the data using ffmpeg and write it to the filesystem. (See the server.js file for where the integration happens)

A video will only be recorded if the app sends a startRecording message over the web socket. This is only the backend, I'll make additional PRs for the app and to add the timeline playback UI to the frontend.

Videos are saved in spatialToolbox/.identity/virtualizer_recordings. The recorded videos can be accessed through the REST interface at localhost:8081/virtualizer_recordings