### PR TITLE
fixes bug when new devices disconnect without starting any recordings

### DIFF
--- a/interfaces/remoteOperatorUI/VideoFileManager.js
+++ b/interfaces/remoteOperatorUI/VideoFileManager.js
@@ -15,7 +15,7 @@ let outputPath = null;
 let persistentInfo = null;
 
 const createMissingDirs = (devicePath) => {
-    utils.mkdirIfNeeded(devicePath);
+    utils.mkdirIfNeeded(devicePath, true);
     let dir = constants.DIR_NAMES;
 
     let sessionVideosPath = path.join(devicePath, dir.session_videos);

--- a/interfaces/remoteOperatorUI/VideoProcessManager.js
+++ b/interfaces/remoteOperatorUI/VideoProcessManager.js
@@ -181,9 +181,10 @@ class Connection {
         }
     }
     stopRecording(didDisconnect) {
-        if (this.isRecording) {
-            this.stopProcesses();
-        }
+        if (!this.isRecording) { return; }
+
+        this.stopProcesses();
+
         if (didDisconnect) {
             this.processStatuses.color = this.STATUS.DISCONNECTED;
             this.processStatuses.depth = this.STATUS.DISCONNECTED;

--- a/interfaces/remoteOperatorUI/VideoServer.js
+++ b/interfaces/remoteOperatorUI/VideoServer.js
@@ -74,7 +74,7 @@ class VideoServer {
     // TODO: this could be optimized by listening for files to finish writing, rather than waiting a fixed time
     onRecordingDone(deviceId, sessionId, lastChunkIndex) {
         setTimeout(() => { // wait for final video to finish processing
-            utils.mkdirIfNeeded(path.join(this.outputPath, deviceId, 'tmp'));
+            utils.mkdirIfNeeded(path.join(this.outputPath, deviceId, 'tmp'), true);
             let tmpOutputPath = path.join(this.outputPath, deviceId, 'tmp', sessionId + '_done_' + lastChunkIndex + '.json');
             fs.writeFileSync(tmpOutputPath, JSON.stringify({ success: true}));
 
@@ -147,7 +147,7 @@ class VideoServer {
 
         // write file list to txt file so it can be used by ffmpeg as input
         let txt_filename = colorOrDepth + '_filenames_' + sessionId + '.txt';
-        utils.mkdirIfNeeded(path.join(this.outputPath, deviceId, 'tmp'));
+        utils.mkdirIfNeeded(path.join(this.outputPath, deviceId, 'tmp'), true);
         let txtFilePath = path.join(this.outputPath, deviceId, 'tmp', txt_filename);
         if (fs.existsSync(txtFilePath)) {
             fs.unlinkSync(txtFilePath);


### PR DESCRIPTION
accidentally pushed a bug in my last PR, server would crash from non-recursive mkdir if device disconnects without having ever recorded in the past to set up the dirs