### PR TITLE
adjust point where 2d video canvas appears

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -420,20 +420,22 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 return;
             }
             
+            let minDist = realityEditor.device.desktopCamera.MIN_DIST_TO_CAMERA;
             let z = -distanceToCamera;
-            let y = -1500 * (z / 3000) * (z / 3000); // camera is positioned along a quadratic curve behind the camera
+            let y = -1500 * ((z+minDist) / 3000) * ((z+minDist) / 3000); // camera is positioned along a quadratic curve behind the camera
             positionObject.position.set(0, y, z);
             positionObject.matrixWorldNeedsUpdate = true;
 
-            z = 1500 * (10000 / (distanceToCamera + 2000)); // target distance decreases hyperbolically as camera distance increases
+            z = 1500 * (10000 / ((distanceToCamera-minDist) + 2000)); // target distance decreases hyperbolically as camera distance increases
             targetObject.position.set(0, 0, z);
             targetObject.matrixWorldNeedsUpdate = true;
 
-            if (this.followingState.currentFollowingDistance === 0 && !this.followingState.currentlyRendering2DVideo) {
+            // let minDist = realityEditor.device.desktopCamera.MIN_DIST_TO_CAMERA;
+            if (this.followingState.currentFollowingDistance <= minDist && !this.followingState.currentlyRendering2DVideo) {
                 realityEditor.gui.ar.desktopRenderer.showCameraCanvas(this.followingState.virtualizerId);
                 this.followingState.currentlyRendering2DVideo = true;
 
-            } else if (this.followingState.currentlyRendering2DVideo && this.followingState.currentFollowingDistance > 0) {
+            } else if (this.followingState.currentlyRendering2DVideo && this.followingState.currentFollowingDistance > minDist) {
                 realityEditor.gui.ar.desktopRenderer.hideCameraCanvas(this.followingState.virtualizerId);
                 this.followingState.currentlyRendering2DVideo = false;
             }
@@ -493,7 +495,8 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                     //     dDist *= percentToClipBy;
                     // }
                     
-                    this.followingState.currentFollowingDistance = Math.min(10000, Math.max(0, this.followingState.currentFollowingDistance + dDist));
+                    let minDist = realityEditor.device.desktopCamera.MIN_DIST_TO_CAMERA;
+                    this.followingState.currentFollowingDistance = Math.min(10000, Math.max(minDist, this.followingState.currentFollowingDistance + dDist));
                     
                     console.log('currentFollowingDistance = ' + this.followingState.currentFollowingDistance);
                     

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -29,6 +29,9 @@ createNameSpace('realityEditor.device.desktopCamera');
         LAB: [0, 0, 0]
     });
 
+    const MIN_DIST_TO_CAMERA = 1500; // the point at which the 2D video will show up
+    exports.MIN_DIST_TO_CAMERA = MIN_DIST_TO_CAMERA;
+
     const perspectives = {
         1: {
             name: 'firstPersonFollow',
@@ -36,7 +39,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             threejsTargetObject: null,
             // positionRelativeToCamera: [0, 0, 0],
             // targetRelativeToCamera: [0, 0, 500],
-            distanceToCamera: 0,
+            distanceToCamera: MIN_DIST_TO_CAMERA,
             smoothing: 0.2,
             debugColor: '#ffffff',
             keyboardShortcut: '_1',
@@ -49,7 +52,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             threejsTargetObject: null,
             // positionRelativeToCamera: [0, -250, -1000],
             // targetRelativeToCamera: [0, 0, 2000],
-            distanceToCamera: 1500,
+            distanceToCamera: 1500 + MIN_DIST_TO_CAMERA,
             smoothing: 0.5,
             debugColor: '#ffffff',
             keyboardShortcut: '_2',
@@ -61,7 +64,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             threejsTargetObject: null,
             // positionRelativeToCamera: [0, -1000, -2000],
             // targetRelativeToCamera: [0, 0, 2000],
-            distanceToCamera: 3000,
+            distanceToCamera: 3000 + MIN_DIST_TO_CAMERA,
             smoothing: 0.5,
             debugColor: '#ffffff',
             keyboardShortcut: '_3',
@@ -73,7 +76,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             threejsTargetObject: null,
             // positionRelativeToCamera: [0, -2000, -3000],
             // targetRelativeToCamera: [0, 0, 2000],
-            distanceToCamera: 4500,
+            distanceToCamera: 4500 + MIN_DIST_TO_CAMERA,
             smoothing: 0.8,
             debugColor: '#ffffff',
             keyboardShortcut: '_4',
@@ -85,7 +88,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             threejsTargetObject: null,
             // positionRelativeToCamera: [0, -5000, -4000],
             // targetRelativeToCamera: [0, 0, 0],
-            distanceToCamera: 6000,
+            distanceToCamera: 6000 + MIN_DIST_TO_CAMERA,
             smoothing: 0.8,
             debugColor: '#ffffff',
             keyboardShortcut: '_5',


### PR DESCRIPTION
effectively moves the camera back a little bit to improve the alignment of the FoVs

side note: currently the aspect ratio of the remote operator window should be roughly the same as the rgb image (I believe a 4x3 ratio (1080x720)), otherwise the canvas is stretched