### PR TITLE
Use virtualizer mesh in first person view; Allow switching camera shader mode

### DIFF
--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -180,16 +180,10 @@ varying vec2 vUv;
 varying vec4 pos;
 
 void main() {
-  // Depth in millimeters
-  float depth = -pos.z;
-
-  // Fade out beginning at 4.5 meters and be gone after 5.0
-  float alphaDepth = clamp(2.0 * (5.0 - depth / 1000.0), 0.0, 1.0);
-
   // Sample the proper color for this pixel from the color image
   vec4 color = texture2D(map, vUv);
 
-  gl_FragColor = vec4(color.rgb, alphaDepth);
+  gl_FragColor = vec4(color.rgb, 1.0);
 }`;
 
     function setMatrixFromArray(matrix, array) {


### PR DESCRIPTION
Uses the point cloud mesh to improve the adaptability of the first person view, switching to a first person mode shader which disables opacity and depth occlusion to be essentially a 2d canvas. Using this approach allows the visualization to adapt to any aspect ratio or rotation.