### PR TITLE
Support for avatar objects + laser beams

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -583,7 +583,10 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             if (totalDifference < 0.00001) {
                 return; // don't animate the matrix with an infinite level of precision, stop when it gets very close to destination
             }
-            let newCameraMatrix = tweenMatrix(currentCameraMatrix, destinationCameraMatrix, 0.3);
+
+            let shouldSmoothCamera = !(this.followingState.active && this.followingState.currentlyRendering2DVideo);
+            let animationSpeed = shouldSmoothCamera ? 0.3 : 1.0;
+            let newCameraMatrix = tweenMatrix(currentCameraMatrix, destinationCameraMatrix, animationSpeed);
 
             if (this.cameraNode.id === 'CAMERA') {
                 realityEditor.sceneGraph.setCameraPosition(newCameraMatrix);

--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -604,7 +604,12 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 return; // don't animate the matrix with an infinite level of precision, stop when it gets very close to destination
             }
             let newCameraMatrix = tweenMatrix(currentCameraMatrix, destinationCameraMatrix, 0.3);
-            this.cameraNode.setLocalMatrix(newCameraMatrix);
+
+            if (this.cameraNode.id === 'CAMERA') {
+                realityEditor.sceneGraph.setCameraPosition(newCameraMatrix);
+            } else {
+                this.cameraNode.setLocalMatrix(newCameraMatrix);
+            }
         }
     }
 

--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -625,12 +625,11 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
 
         // now process the other objects
         Object.keys(objects).forEach(function(objectKey) {
-            // todo: check if object.worldId matches a world that is currently loaded
             let object = objects[objectKey];
 
-            // always add world object to scene unles we set a primaryWorldId in the URLSearchParams
-            if (object.isWorldObject || object.type === 'world') {
-                return; // already processed
+            // we already added world objects. also ignore the avatar objects
+            if (object.isWorldObject || object.type === 'world' || object.type === 'avatar') {
+                return;
             }
 
             // if there isn't a world object, it's ok to load objects without a world (e.g. as a debugger)

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -141,7 +141,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             0, 0, 0, 1
         ];
     }
-    
+
     function makeGroundPlaneRotationY(theta) {
         var c = Math.cos(theta), s = Math.sin(theta);
         return [
@@ -181,7 +181,7 @@ createNameSpace('realityEditor.device.desktopCamera');
         let transformationMatrix = makeGroundPlaneRotationX(0);
         transformationMatrix[13] = 1286; // ground plane translation
         cameraGroupContainer.setLocalMatrix(transformationMatrix);
-        
+
         // let elementId = realityEditor.sceneGraph.getVisualElement('CameraGroupContainer');
 
         let cameraNode = realityEditor.sceneGraph.getSceneNodeById('CAMERA');
@@ -294,7 +294,7 @@ createNameSpace('realityEditor.device.desktopCamera');
         //     let virtualizerSceneNodes = realityEditor.gui.ar.desktopRenderer.getCameraVisSceneNodes();
         //     if (virtualizerSceneNodes.length > 0) {
         //         virtualCamera.follow1stPerson(virtualizerSceneNodes[0]);
-        //         unityCamera.follow1stPerson(virtualizerSceneNodes[0]);                
+        //         unityCamera.follow1stPerson(virtualizerSceneNodes[0]);
         //     }
         // });
         //
@@ -320,7 +320,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             closestObjectLog.style.color = 'cyan';
             document.body.appendChild(closestObjectLog);
         }
-        
+
         // Setup Following Menu
         for (let info of Object.values(perspectives)) {
             const followItem = new realityEditor.gui.MenuItem(info.menuBarName, { shortcutKey: info.keyboardShortcut, toggle: false, disabled: true }, () => {
@@ -329,7 +329,7 @@ createNameSpace('realityEditor.device.desktopCamera');
                     const thisVirtualizerId = parseInt(virtualizerSceneNodes[0].id.match(/\d+/)[0]); // TODO: pass this along in a less fragile way
                     virtualCamera.follow(virtualizerSceneNodes[0], thisVirtualizerId, info);
                     unityCamera.follow(virtualizerSceneNodes[0], thisVirtualizerId, info);
-                    
+
                     if (info.render2DVideo) {
                         realityEditor.gui.ar.desktopRenderer.showCameraCanvas(thisVirtualizerId);
                     } else {

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -131,6 +131,10 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 
                     realityEditor.device.meshLine.inject();
 
+                    // this will trigger any onLocalizedWithinWorld callbacks in the userinterface, such as creating the Avatar
+                    let identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+                    realityEditor.worldObjects.setOrigin(objectKey, identity);
+
                     let realityZoneVoxelizer;
                     if (ENABLE_VOXELIZER) {
                         realityZoneVoxelizer = new realityEditor.gui.ar.desktopRenderer.RealityZoneVoxelizer(floorOffset, wireframe, navmesh);

--- a/content_scripts/desktopStats.js
+++ b/content_scripts/desktopStats.js
@@ -29,20 +29,29 @@ createNameSpace('realityEditor.device.desktopStats');
     function initService() {
         if (!realityEditor.device.desktopAdapter.isDesktop()) { return; }
 
-        document.body.appendChild(stats.dom);
+        setTimeout(() => {
 
-    	imagesPerSecondElement = document.createElement('div');
-    	imagesPerSecondElement.style.color = 'white';
-    	imagesPerSecondElement.style.fontSize = '30px';
-    	imagesPerSecondElement.style.position = 'absolute';
-    	imagesPerSecondElement.style.left = '100px';
-    	imagesPerSecondElement.style.top = '0';
-    	document.body.appendChild(imagesPerSecondElement);
+            stats.dom.position = 'absolute';
+            stats.dom.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
+            document.body.appendChild(stats.dom);
+            stats.dom.style.left = (window.innerWidth - stats.dom.getBoundingClientRect().width) + 'px';
 
-    	isVisible = true;
+            imagesPerSecondElement = document.createElement('div');
+            imagesPerSecondElement.style.color = 'white';
+            imagesPerSecondElement.style.fontSize = '30px';
+            imagesPerSecondElement.style.position = 'absolute';
+            imagesPerSecondElement.style.right = '100px';
+            imagesPerSecondElement.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
+            document.body.appendChild(imagesPerSecondElement);
 
-	    update(); // start update loop
-        hide(); // default hidden
+            isVisible = true;
+
+            update(); // start update loop
+            // hide(); // default hidden
+            show();
+
+        }, 1000);
+
     }
 
     function update() {

--- a/content_scripts/desktopStats.js
+++ b/content_scripts/desktopStats.js
@@ -29,29 +29,31 @@ createNameSpace('realityEditor.device.desktopStats');
     function initService() {
         if (!realityEditor.device.desktopAdapter.isDesktop()) { return; }
 
-        setTimeout(() => {
+        // wait until the menubar is initialized
+        if (typeof realityEditor.gui.setupMenuBar !== 'function') {
+            setTimeout(initService, 100);
+            return;
+        }
+        realityEditor.gui.setupMenuBar(); // this can be safely called multiple times to ensure it is created
 
-            stats.dom.position = 'absolute';
-            stats.dom.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
-            document.body.appendChild(stats.dom);
-            stats.dom.style.left = (window.innerWidth - stats.dom.getBoundingClientRect().width) + 'px';
+        stats.dom.position = 'absolute';
+        stats.dom.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
+        document.body.appendChild(stats.dom);
+        stats.dom.style.left = (window.innerWidth - stats.dom.getBoundingClientRect().width) + 'px';
 
-            imagesPerSecondElement = document.createElement('div');
-            imagesPerSecondElement.style.color = 'white';
-            imagesPerSecondElement.style.fontSize = '30px';
-            imagesPerSecondElement.style.position = 'absolute';
-            imagesPerSecondElement.style.right = '100px';
-            imagesPerSecondElement.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
-            document.body.appendChild(imagesPerSecondElement);
+        imagesPerSecondElement = document.createElement('div');
+        imagesPerSecondElement.style.color = 'white';
+        imagesPerSecondElement.style.fontSize = '30px';
+        imagesPerSecondElement.style.position = 'absolute';
+        imagesPerSecondElement.style.right = '100px';
+        imagesPerSecondElement.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
+        document.body.appendChild(imagesPerSecondElement);
 
-            isVisible = true;
+        isVisible = true;
 
-            update(); // start update loop
-            // hide(); // default hidden
-            show();
-
-        }, 1000);
-
+        update(); // start update loop
+        // hide(); // default hidden
+        show();
     }
 
     function update() {

--- a/content_scripts/multiclientUI.js
+++ b/content_scripts/multiclientUI.js
@@ -66,6 +66,26 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         });
 
         update();
+
+        let keyboard = new realityEditor.device.KeyboardListener();
+        keyboard.onKeyDown(function(code) {
+            if (realityEditor.device.keyboardEvents.isKeyboardActive()) { return; } // ignore if a tool is using the keyboard
+
+            // while shift is down, turn on the laser beam
+            if (code === keyboard.keyCodes.SHIFT) {
+                let touchPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
+                realityEditor.avatarObjects.setBeamOn(touchPosition.x, touchPosition.y);
+            }
+        });
+        keyboard.onKeyUp(function(code) {
+            if (realityEditor.device.keyboardEvents.isKeyboardActive()) { return; } // ignore if a tool is using the keyboard
+
+            // when shift is released, turn off the laser beam
+            if (code === keyboard.keyCodes.SHIFT) {
+                let touchPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
+                realityEditor.avatarObjects.setBeamOff(touchPosition.x, touchPosition.y);
+            }
+        });
     }
 
     function setupWorldSocketSubscriptionsIfNeeded(objectKey) {

--- a/content_scripts/setupMenuBar.js
+++ b/content_scripts/setupMenuBar.js
@@ -35,6 +35,8 @@ createNameSpace('realityEditor.gui');
     // sets up the initial contents of the menuBar
     // other modules can add more to it by calling getMenuBar().addItemToMenu(menuName, menuItem)
     const setupMenuBar = () => {
+        if (menuBar) { return; }
+
         const MenuBar = realityEditor.gui.MenuBar;
         const Menu = realityEditor.gui.Menu;
         const MenuItem = realityEditor.gui.MenuItem;


### PR DESCRIPTION
- Optimizes camera to work with an avatar object
- Adds SHIFT keyboard shortcut to trigger laser beam while held down
- simplifies multiclientUI icosahedron into a smaller cube (for now – still could use improvement but looking for something more subtle) 

Requires https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/243