### PR TITLE
remove keyboard shortcut to make P key show/hide groundplane anchors,…

### DIFF
--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -204,9 +204,6 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
                         startY: touchPosition.y
                     };
                 }
-            } else if (code === keyboard.keyCodes.P) {
-                console.log('Key P pressed - toggle positioning mode');
-                realityEditor.gui.ar.groundPlaneAnchors.togglePositioningMode();
             }
         });
         keyboard.onKeyUp(function(code) {


### PR DESCRIPTION
… since P is used for Clone Patch