### PR TITLE
SpaghettiMeshPath for historyLines

### DIFF
--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -3,7 +3,6 @@ createNameSpace('realityEditor.device.cameraVis');
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
 import {rvl} from '../../thirdPartyCode/rvl/index.js';
 import RVLParser from '../../thirdPartyCode/rvl/RVLParser.js';
-import { MeshPath } from '../../src/gui/ar/meshPath.js';
 import { SpaghettiMeshPath } from '../../src/humanPose/spaghetti.js';
 
 (function(exports) {
@@ -214,7 +213,7 @@ void main() {
         );
     }
 
-    // https://www.30secondsofcode.org/js/s/hsl-to-rgb
+    // author: https://www.30secondsofcode.org/js/s/hsl-to-rgb
     // input ranges: H: [0, 360], S: [0, 100], L: [0, 100]
     // output ranges: [0, 255]
     function HSLToRGB(h, s, l) {
@@ -313,18 +312,15 @@ void main() {
             this.loading = {};
 
             this.historyPoints = [];
+            // note: we will color the path in each point, rather than in the constructor
             this.historyMesh = new SpaghettiMeshPath(this.historyPoints, {
                 width_mm: 30,
                 height_mm: 30,
-                // horizontalColor: color,
-                // wallColor: colorDarker,
                 usePerVertexColors: true,
-                colorBlending: false,
-                wallBrightness: 0.6,
-                // opacity: 0.8,
+                wallBrightness: 0.6
             });
             
-            // we add the historyMesh to scene because it gets messed up by rotation if added to this.container
+            // we add the historyMesh to scene because crossing up vector gets messed up by rotation if added to this.container
             realityEditor.gui.threejsScene.addToScene(this.historyMesh);
         }
 

--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -3,6 +3,7 @@ createNameSpace('realityEditor.device.cameraVis');
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
 import {rvl} from '../../thirdPartyCode/rvl/index.js';
 import RVLParser from '../../thirdPartyCode/rvl/RVLParser.js';
+import { MeshPath } from '../../src/gui/ar/meshPath.js';
 
 (function(exports) {
     const debug = false;
@@ -248,6 +249,7 @@ void main() {
                 }
             }
             const color = `hsl(${((colorId / 29) % Math.PI) * 360 / Math.PI}, 100%, 50%)`;
+            const colorDarker = `hsl(${((colorId / 29) % Math.PI) * 360 / Math.PI}, 100%, 30%)`;
             const mat = new THREE.MeshBasicMaterial({color: color});
             const box = new THREE.Mesh(geo, mat);
             box.name = 'cameraVisCamera';
@@ -294,18 +296,28 @@ void main() {
             this.matrices = [];
             this.loading = {};
 
-            this.historyLine = new realityEditor.device.meshLine.MeshLine();
-            const lineMat = new realityEditor.device.meshLine.MeshLineMaterial({
-                color: color,
-                opacity: 0.6,
-                lineWidth: 20,
-                // depthWrite: false,
-                transparent: true,
-                side: THREE.DoubleSide,
-            });
-            this.historyMesh = new THREE.Mesh(this.historyLine, lineMat);
+            // this.historyLine = new realityEditor.device.meshLine.MeshLine();
+            // const lineMat = new realityEditor.device.meshLine.MeshLineMaterial({
+            //     color: color,
+            //     opacity: 0.6,
+            //     lineWidth: 20,
+            //     // depthWrite: false,
+            //     transparent: true,
+            //     side: THREE.DoubleSide,
+            // });
+            // this.historyMesh = new THREE.Mesh(this.historyLine, lineMat);
             this.historyPoints = [];
-            this.historyLine.setPoints(this.historyPoints);
+            // this.historyLine.setPoints(this.historyPoints);
+
+            this.historyMesh = new MeshPath(this.historyPoints, {
+                topColor: color,
+                wallColor: colorDarker,
+                width_mm: 30,
+                height_mm: 30,
+                bottomScale: 1,
+                usePerVertexColors: false
+            });
+            
             this.container.add(this.historyMesh);
         }
 
@@ -573,7 +585,7 @@ void main() {
 
             if (addToHistory) {
                 this.historyPoints.push(nextHistoryPoint);
-                this.historyLine.setPoints(this.historyPoints);
+                this.historyMesh.setPoints(this.historyPoints);
             }
 
             if (this.sceneGraphNode) {
@@ -670,7 +682,7 @@ void main() {
             realityEditor.gui.getMenuBar().addCallbackToItem(realityEditor.gui.ITEM.ResetPaths, () => {
                 for (let camera of Object.values(this.cameras)) {
                     camera.historyPoints = [];
-                    camera.historyLine.setPoints(camera.historyPoints);
+                    camera.historyMesh.setPoints(camera.historyPoints);
                 }
             });
 


### PR DESCRIPTION
Makes use of https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/317 to make the CameraVis leave a SpaghettiMeshPath trail instead of a MeshLine trail.

![spaghettiMeshPath-demo](https://user-images.githubusercontent.com/32580292/204932945-2b7633ef-fad8-4d90-b5d6-74845b36d5d3.gif)
