### PR TITLE
Utilize area target frustum culling shader

### DIFF
--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -569,6 +569,8 @@ void main() {
             this.texture.needsUpdate = true;
             this.textureDepth.needsUpdate = true;
 
+            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(this.id, this.phone.matrixWorld);
+
             this.hideNearCamera(newMatrix[12], newMatrix[13], newMatrix[14]);
             let localHistoryPoint = new THREE.Vector3( newMatrix[12], newMatrix[13], newMatrix[14]);
 
@@ -577,10 +579,6 @@ void main() {
             let rootNode = realityEditor.sceneGraph.getSceneNodeById('ROOT');
             let gpNode = realityEditor.sceneGraph.getGroundPlaneNode();
             let gpHistoryPoint = realityEditor.sceneGraph.convertToNewCoordSystem(worldHistoryPoint, rootNode, gpNode);
-            let gpCameraMatrix = realityEditor.sceneGraph.convertToNewCoordSystem(this.phone.matrixWorld, rootNode, gpNode);
-
-            // realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(gpCameraMatrix);
-            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(this.id, this.phone.matrixWorld);
 
             let nextHistoryPoint = {
                 x: gpHistoryPoint.x,

--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -579,8 +579,8 @@ void main() {
             let gpHistoryPoint = realityEditor.sceneGraph.convertToNewCoordSystem(worldHistoryPoint, rootNode, gpNode);
             let gpCameraMatrix = realityEditor.sceneGraph.convertToNewCoordSystem(this.phone.matrixWorld, rootNode, gpNode);
 
-            // realityEditor.gui.ar.desktopRenderer.setBubbleCenter(gpHistoryPoint.x, gpHistoryPoint.y, gpHistoryPoint.z, this.phone.matrixWorld);
-            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(gpCameraMatrix);
+            // realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(gpCameraMatrix);
+            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(this.id, this.phone.matrixWorld);
 
             let nextHistoryPoint = {
                 x: gpHistoryPoint.x,

--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -577,8 +577,10 @@ void main() {
             let rootNode = realityEditor.sceneGraph.getSceneNodeById('ROOT');
             let gpNode = realityEditor.sceneGraph.getGroundPlaneNode();
             let gpHistoryPoint = realityEditor.sceneGraph.convertToNewCoordSystem(worldHistoryPoint, rootNode, gpNode);
+            let gpCameraMatrix = realityEditor.sceneGraph.convertToNewCoordSystem(this.phone.matrixWorld, rootNode, gpNode);
 
-            realityEditor.gui.ar.desktopRenderer.setBubbleCenter(gpHistoryPoint.x, gpHistoryPoint.y, gpHistoryPoint.z, this.phone.matrixWorld);
+            // realityEditor.gui.ar.desktopRenderer.setBubbleCenter(gpHistoryPoint.x, gpHistoryPoint.y, gpHistoryPoint.z, this.phone.matrixWorld);
+            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(gpCameraMatrix);
 
             let nextHistoryPoint = {
                 x: gpHistoryPoint.x,

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -155,6 +155,7 @@ createNameSpace('realityEditor.device.desktopCamera');
         virtualCamera.onRotateToggled(function(isRotating) {
             if (isRotating && !knownInteractionStates.rotate) {
                 knownInteractionStates.rotate = true;
+                knownInteractionStates.pan = false; // stop panning if you start rotating
                 // console.log('start rotate');
                 rotateToggled();
             } else if (!isRotating && knownInteractionStates.rotate) {

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -457,26 +457,107 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         return cameraVisSceneNodes;
     };
     
-    exports.setBubbleCenter = function(x, y, z, cameraVisMatrix) {
+    // exports.setBubbleCenter = function(x, y, z, cameraVisMatrix) {
+    //     if (!gltf || typeof gltf.traverse === 'undefined') return;
+    //     const utils = realityEditor.gui.ar.utilities;
+    //     const SCALE = 1000;
+    //     let groundPlaneSceneNode = realityEditor.sceneGraph.getGroundPlaneNode();
+    //     let worldSceneNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId());
+    //     let cameraMatrix = realityEditor.sceneGraph.convertToNewCoordSystem(cameraVisMatrix, worldSceneNode, groundPlaneSceneNode);
+    //     // compute dot product of camera forward and new tool forward to see whether it's facing towards or away from you
+    //     let cameraForward = utils.normalize(utils.getForwardVector(cameraMatrix.elements));
+    //
+    //     gltf.traverse(child => {
+    //         if (!child.material || !child.material.uniforms) return;
+    //
+    //         // console.log('set: ', child.material.uniforms['bubble'].value);
+    //         child.material.uniforms['coneTipPoint'].value = new THREE.Vector3(x/SCALE, y/SCALE, z/SCALE);
+    //        
+    //         child.material.uniforms['coneDirection'].value = new THREE.Vector3(cameraForward[0], cameraForward[1], cameraForward[2]);
+    //         // console.log('set: ', child.material.uniforms['bubble'].value);
+    //         // child.material.uniforms['bubble'].value = new THREE.Vector3(x/SCALE, y/SCALE, z/SCALE);
+    //
+    //     });
+    // }
+    
+    function array3ToXYZ(arr3) {
+        return new THREE.Vector3(arr3[0], arr3[1], arr3[2]);
+    }
+    
+    exports.updateAreaGltfForCamera = function(gpCameraMatrix) {
         if (!gltf || typeof gltf.traverse === 'undefined') return;
         const utils = realityEditor.gui.ar.utilities;
+        const UNIFORMS = Object.freeze({
+            coneTipPoint: 'coneTipPoint',
+            coneDirection: 'coneDirection',
+            coneHeight: 'coneHeight',
+            coneBaseRadius: 'coneBaseRadius',
+            p: 'p',
+            l: 'l',
+            u: 'u',
+            normal1: 'normal1',
+            normal2: 'normal2',
+            normal3: 'normal3',
+            normal4: 'normal4',
+            normal5: 'normal5',
+            normal6: 'normal6',
+            D1: 'D1',
+            D2: 'D2',
+            D3: 'D3',
+            D4: 'D4',
+            D5: 'D5',
+            D6: 'D6'
+        });
         const SCALE = 1000;
-        let groundPlaneSceneNode = realityEditor.sceneGraph.getGroundPlaneNode();
-        let worldSceneNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId());
-        let cameraMatrix = realityEditor.sceneGraph.convertToNewCoordSystem(cameraVisMatrix, worldSceneNode, groundPlaneSceneNode);
-        // compute dot product of camera forward and new tool forward to see whether it's facing towards or away from you
-        let cameraForward = utils.normalize(utils.getForwardVector(cameraMatrix.elements));
+
+        let cameraPosition = new THREE.Vector3(
+            gpCameraMatrix.elements[12]/SCALE,
+            gpCameraMatrix.elements[13]/SCALE,
+            gpCameraMatrix.elements[14]/SCALE
+        );
+        let cameraDirection = utils.normalize(utils.getForwardVector(gpCameraMatrix.elements));
+        let cameraUp = utils.normalize(utils.getUpVector(gpCameraMatrix.elements));
+        
+        let frustumPlanes = realityEditor.gui.threejsScene.updateFrustum([cameraPosition.x, cameraPosition.y, cameraPosition.z], cameraDirection, cameraUp);
 
         gltf.traverse(child => {
             if (!child.material || !child.material.uniforms) return;
-
-            // console.log('set: ', child.material.uniforms['bubble'].value);
-            child.material.uniforms['coneTipPoint'].value = new THREE.Vector3(x/SCALE, y/SCALE, z/SCALE);
             
-            child.material.uniforms['coneDirection'].value = new THREE.Vector3(cameraForward[0], cameraForward[1], cameraForward[2]);
-            // console.log('set: ', child.material.uniforms['bubble'].value);
-            // child.material.uniforms['bubble'].value = new THREE.Vector3(x/SCALE, y/SCALE, z/SCALE);
+            // if (typeof child.material.uniforms[UNIFORMS.coneTipPoint] !== 'undefined') {
+            //     child.material.uniforms[UNIFORMS.coneTipPoint].value = cameraPosition;
+            //     child.material.uniforms[UNIFORMS.coneDirection].value = cameraDirection;
+            //     child.material.uniforms[UNIFORMS.coneHeight].value = 5.0; // LiDAR extends for 5 meter range
+            //     child.material.uniforms[UNIFORMS.coneBaseRadius].value = 3.0; // todo: figure out optimal value to match FoV
+            // }
+            //
+            // if (typeof child.material.uniforms[UNIFORMS.p] !== 'undefined') {
+            //     child.material.uniforms[UNIFORMS.p].value = cameraPosition;
+            //     child.material.uniforms[UNIFORMS.l].value = cameraDirection;
+            //
+            //     // p: {value: new THREE.Vector3(0, 0, 0)},
+            //     // l: {value: new THREE.Vector3(1, 0, 0)},
+            //     // u: {value: new THREE.Vector3(0, 1, 0)}
+            // }
 
+            if (typeof child.material.uniforms[UNIFORMS.normal1] !== 'undefined') {
+                child.material.uniforms[UNIFORMS.normal1].value = array3ToXYZ(frustumPlanes.normal1);
+                child.material.uniforms[UNIFORMS.normal2].value = array3ToXYZ(frustumPlanes.normal2);
+                child.material.uniforms[UNIFORMS.normal3].value = array3ToXYZ(frustumPlanes.normal3);
+                child.material.uniforms[UNIFORMS.normal4].value = array3ToXYZ(frustumPlanes.normal4);
+                child.material.uniforms[UNIFORMS.normal5].value = array3ToXYZ(frustumPlanes.normal5);
+                child.material.uniforms[UNIFORMS.normal6].value = array3ToXYZ(frustumPlanes.normal6);
+
+                child.material.uniforms[UNIFORMS.D1].value = frustumPlanes.D1;
+                child.material.uniforms[UNIFORMS.D2].value = frustumPlanes.D2;
+                child.material.uniforms[UNIFORMS.D3].value = frustumPlanes.D3;
+                child.material.uniforms[UNIFORMS.D4].value = frustumPlanes.D4;
+                child.material.uniforms[UNIFORMS.D5].value = frustumPlanes.D5;
+                child.material.uniforms[UNIFORMS.D6].value = frustumPlanes.D6;
+
+                // p: {value: new THREE.Vector3(0, 0, 0)},
+                // l: {value: new THREE.Vector3(1, 0, 0)},
+                // u: {value: new THREE.Vector3(0, 1, 0)}
+            }
         });
     }
 

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -9,6 +9,7 @@
 createNameSpace('realityEditor.gui.ar.desktopRenderer');
 
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
+import { UNIFORMS } from '../../src/gui/ViewFrustum.js';
 
 /**
  * @fileOverview realityEditor.device.desktopRenderer.js
@@ -457,68 +458,16 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         return cameraVisSceneNodes;
     };
     
-    // exports.setBubbleCenter = function(x, y, z, cameraVisMatrix) {
-    //     if (!gltf || typeof gltf.traverse === 'undefined') return;
-    //     const utils = realityEditor.gui.ar.utilities;
-    //     const SCALE = 1000;
-    //     let groundPlaneSceneNode = realityEditor.sceneGraph.getGroundPlaneNode();
-    //     let worldSceneNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId());
-    //     let cameraMatrix = realityEditor.sceneGraph.convertToNewCoordSystem(cameraVisMatrix, worldSceneNode, groundPlaneSceneNode);
-    //     // compute dot product of camera forward and new tool forward to see whether it's facing towards or away from you
-    //     let cameraForward = utils.normalize(utils.getForwardVector(cameraMatrix.elements));
-    //
-    //     gltf.traverse(child => {
-    //         if (!child.material || !child.material.uniforms) return;
-    //
-    //         // console.log('set: ', child.material.uniforms['bubble'].value);
-    //         child.material.uniforms['coneTipPoint'].value = new THREE.Vector3(x/SCALE, y/SCALE, z/SCALE);
-    //        
-    //         child.material.uniforms['coneDirection'].value = new THREE.Vector3(cameraForward[0], cameraForward[1], cameraForward[2]);
-    //         // console.log('set: ', child.material.uniforms['bubble'].value);
-    //         // child.material.uniforms['bubble'].value = new THREE.Vector3(x/SCALE, y/SCALE, z/SCALE);
-    //
-    //     });
-    // }
-    
     function array3ToXYZ(arr3) {
         return new THREE.Vector3(arr3[0], arr3[1], arr3[2]);
     }
-
-    // window.xval = 0;
-    // window.yval = 0;
-    // window.zval = 0;
-    
-    let counter = 0;
-    const maxCount = 30;
-
-    const UNIFORMS = Object.freeze({
-        coneTipPoint: 'coneTipPoint',
-        coneDirection: 'coneDirection',
-        coneHeight: 'coneHeight',
-        coneBaseRadius: 'coneBaseRadius',
-        p: 'p',
-        l: 'l',
-        u: 'u',
-        normal1: 'normal1',
-        normal2: 'normal2',
-        normal3: 'normal3',
-        normal4: 'normal4',
-        normal5: 'normal5',
-        normal6: 'normal6',
-        D1: 'D1',
-        D2: 'D2',
-        D3: 'D3',
-        D4: 'D4',
-        D5: 'D5',
-        D6: 'D6'
-    });
     const SCALE = 1000;
     
-    exports.updateAreaGltfForCamera = function(gpCameraMatrix) {
+    exports.updateAreaGltfForCamera = function(cameraId, gpCameraMatrix) {
         if (!gltf || typeof gltf.traverse === 'undefined') return;
         const utils = realityEditor.gui.ar.utilities;
         
-        const VERTICAL_OFFSET = -0.35; // empirically determined
+        const VERTICAL_OFFSET = 0; // -0.35; // empirically determined
 
         let cameraPosition = new THREE.Vector3(
             gpCameraMatrix.elements[12]/SCALE,
@@ -527,73 +476,31 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         );
         let cameraPos = [cameraPosition.x, cameraPosition.y + VERTICAL_OFFSET, cameraPosition.z];
 
-        let cameraDirection = utils.normalize(utils.getForwardVector(gpCameraMatrix.elements)); // [0, 0, 1]; // 
+        let cameraDirection = utils.normalize(utils.getForwardVector(gpCameraMatrix.elements));
         let cameraLookAtPosition = utils.add(cameraPos, cameraDirection);
-        let cameraUp = utils.normalize(utils.getUpVector(gpCameraMatrix.elements)); // [-1, 0, 0]; // 
+        let cameraUp = utils.normalize(utils.getUpVector(gpCameraMatrix.elements));
+
+        let frustumPlanes = realityEditor.gui.threejsScene.updateFrustum(cameraId, cameraPos, cameraLookAtPosition, cameraUp);
+        frustumPlanes.normal1 = array3ToXYZ(frustumPlanes.normal1);
+        frustumPlanes.normal2 = array3ToXYZ(frustumPlanes.normal2);
+        frustumPlanes.normal3 = array3ToXYZ(frustumPlanes.normal3);
+        frustumPlanes.normal4 = array3ToXYZ(frustumPlanes.normal4);
+        frustumPlanes.normal5 = array3ToXYZ(frustumPlanes.normal5);
+        frustumPlanes.normal6 = array3ToXYZ(frustumPlanes.normal6);
         
-        // let cameraPos = [cameraPosition.x * window.xval, cameraPosition.y * window.yval, cameraPosition.z * window.zval];
-        
-        // counter++;
-        // if (counter > maxCount) {
-        //     console.log(cameraPos, cameraDirection, cameraUp);
-        //     counter = 0;
-        // }
-
-
-        let frustumPlanes = realityEditor.gui.threejsScene.updateFrustum(cameraPos, cameraLookAtPosition, cameraUp);
-
         gltf.traverse(child => {
             updateUniforms(child, frustumPlanes);
         });
     }
-    
-    setInterval(() => {
-        if (window.debugCube) {
-            let cameraPos = [0, 0, 0];
-            let cameraDirection = [0, 0, 1]; // utils.normalize(utils.getForwardVector(gpCameraMatrix.elements));
-            let cameraUp = [-1, 0, 0]; // utils.normalize(utils.getUpVector(gpCameraMatrix.elements));
-            let frustumPlanes = realityEditor.gui.threejsScene.updateFrustum(cameraPos, cameraDirection, cameraUp);
-            updateUniforms(window.debugCube, frustumPlanes);
-        }
-    }, 100);
-    
+
     function updateUniforms(child, frustumPlanes) {
         if (!child.material || !child.material.uniforms) return;
 
-        // if (typeof child.material.uniforms[UNIFORMS.coneTipPoint] !== 'undefined') {
-        //     child.material.uniforms[UNIFORMS.coneTipPoint].value = cameraPosition;
-        //     child.material.uniforms[UNIFORMS.coneDirection].value = cameraDirection;
-        //     child.material.uniforms[UNIFORMS.coneHeight].value = 5.0; // LiDAR extends for 5 meter range
-        //     child.material.uniforms[UNIFORMS.coneBaseRadius].value = 3.0; // todo: figure out optimal value to match FoV
-        // }
-        //
-        // if (typeof child.material.uniforms[UNIFORMS.p] !== 'undefined') {
-        //     child.material.uniforms[UNIFORMS.p].value = cameraPosition;
-        //     child.material.uniforms[UNIFORMS.l].value = cameraDirection;
-        //
-        //     // p: {value: new THREE.Vector3(0, 0, 0)},
-        //     // l: {value: new THREE.Vector3(1, 0, 0)},
-        //     // u: {value: new THREE.Vector3(0, 1, 0)}
-        // }
-
-        if (typeof child.material.uniforms[UNIFORMS.normal1] !== 'undefined') {
-            child.material.uniforms[UNIFORMS.normal1].value = array3ToXYZ(frustumPlanes.normal1);
-            child.material.uniforms[UNIFORMS.normal2].value = array3ToXYZ(frustumPlanes.normal2);
-            child.material.uniforms[UNIFORMS.normal3].value = array3ToXYZ(frustumPlanes.normal3);
-            child.material.uniforms[UNIFORMS.normal4].value = array3ToXYZ(frustumPlanes.normal4);
-            child.material.uniforms[UNIFORMS.normal5].value = array3ToXYZ(frustumPlanes.normal5);
-            child.material.uniforms[UNIFORMS.normal6].value = array3ToXYZ(frustumPlanes.normal6);
-
-            child.material.uniforms[UNIFORMS.D1].value = frustumPlanes.D1;
-            child.material.uniforms[UNIFORMS.D2].value = frustumPlanes.D2;
-            child.material.uniforms[UNIFORMS.D3].value = frustumPlanes.D3;
-            child.material.uniforms[UNIFORMS.D4].value = frustumPlanes.D4;
-            child.material.uniforms[UNIFORMS.D5].value = frustumPlanes.D5;
-            child.material.uniforms[UNIFORMS.D6].value = frustumPlanes.D6;
-
-            // p: {value: new THREE.Vector3(0, 0, 0)},
-            // l: {value: new THREE.Vector3(1, 0, 0)},
-            // u: {value: new THREE.Vector3(0, 1, 0)}
+        if (typeof child.material.uniforms[UNIFORMS.numFrustums] !== 'undefined') {
+            let existingFrustums = child.material.uniforms[UNIFORMS.frustums].value;
+            existingFrustums[0] = frustumPlanes; // todo: get index based on cameraId
+            child.material.uniforms[UNIFORMS.frustums].value = existingFrustums;
+            child.material.needsUpdate = true
         }
     }
 


### PR DESCRIPTION
Goes with https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/319

Updates the ViewFrustums in the threejsInterface with the camera position and orientation of each virtualizer, and uploads the resulting geometry to the shader uniforms to discard points underneath the pointclouds.

I'm apparently tired and accidentally pushed my branch to main while rebasing, but this should also hopefully fix any weird state from that push. 💀 