### PR TITLE
CameraVis stores maxDepthMeters on each update

### DIFF
--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -246,6 +246,8 @@ void main() {
             this.phone.frustumCulled = false;
             this.container.add(this.phone);
 
+            this.maxDepthMeters = 5; // this goes down if lidar is pointed at a wall/floor/object closer than 5 meters
+
             let parentNode = realityEditor.sceneGraph.getVisualElement('CameraGroupContainer');
             // let parentNode = realityEditor.sceneGraph.getGroundPlaneNode();
             // let parentNode = realityEditor.sceneGraph.getSceneNodeById(elementId);
@@ -569,7 +571,7 @@ void main() {
             this.texture.needsUpdate = true;
             this.textureDepth.needsUpdate = true;
 
-            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(this.id, this.phone.matrixWorld);
+            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(this.id, this.phone.matrixWorld, this.maxDepthMeters);
 
             this.hideNearCamera(newMatrix[12], newMatrix[13], newMatrix[14]);
             let localHistoryPoint = new THREE.Vector3( newMatrix[12], newMatrix[13], newMatrix[14]);
@@ -927,7 +929,11 @@ void main() {
             let {canvas, context, imageData} = this.depthCanvasCache[id];
             canvas.width = DEPTH_WIDTH;
             canvas.height = DEPTH_HEIGHT;
+            let maxDepth14bits = 0;
             for (let i = 0; i < DEPTH_WIDTH * DEPTH_HEIGHT; i++) {
+                if (rawDepth[i] > maxDepth14bits) {
+                    maxDepth14bits = rawDepth[i];
+                }
                 // We get 14 bits of depth information from the RVL-encoded
                 // depth buffer. Note that this means the blue channel is
                 // always zero
@@ -943,6 +949,7 @@ void main() {
                 imageData.data[4 * i + 2] = b;
                 imageData.data[4 * i + 3] = 255;
             }
+            this.cameras[id].maxDepthMeters = 5 * (maxDepth14bits / (1 << 14));
 
             context.putImageData(imageData, 0, 0);
             this.finishRenderPointCloudCanvas(id, textureKey, -1);

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -474,7 +474,7 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
         return cameraVisSceneNodes;
     };
     
-    exports.updateAreaGltfForCamera = function(cameraId, cameraWorldMatrix) {
+    exports.updateAreaGltfForCamera = function(cameraId, cameraWorldMatrix, maxDepthMeters) {
         if (!gltf || typeof gltf.traverse === 'undefined') return;
         const utils = realityEditor.gui.ar.utilities;
         
@@ -488,7 +488,7 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
         let cameraLookAtPosition = utils.add(cameraPos, cameraDirection);
         let cameraUp = utils.normalize(utils.getUpVector(cameraWorldMatrix.elements));
 
-        let thisFrustumPlanes = realityEditor.gui.threejsScene.updateMaterialCullingFrustum(cameraId, cameraPos, cameraLookAtPosition, cameraUp);
+        let thisFrustumPlanes = realityEditor.gui.threejsScene.updateMaterialCullingFrustum(cameraId, cameraPos, cameraLookAtPosition, cameraUp, maxDepthMeters);
         
         gltf.traverse(child => {
             updateFrustumUniforms(child, cameraId, thisFrustumPlanes);


### PR DESCRIPTION
Can be used to shorten the culling frustum if you're looking at a wall/object that fills your screen.