### PR TITLE
adjust the drop distance for new tools to always be placed at the camera focus point (if not anchored to mesh)

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -211,13 +211,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             this.targetPosition = [0, 0, 0];
         }
         adjustEnvVars(distanceToTarget) {
-            if (distanceToTarget < 3000) {
-                realityEditor.device.environment.variables.newFrameDistanceMultiplier = 6;
-            } else if (distanceToTarget < 12000) {
-                realityEditor.device.environment.variables.newFrameDistanceMultiplier = 6 * (distanceToTarget / 3000);
-            } else {
-                realityEditor.device.environment.variables.newFrameDistanceMultiplier = 6 * (4);
-            }
+            realityEditor.device.environment.variables.newFrameDistanceMultiplier = distanceToTarget / 400;
         }
         getTargetMatrix() {
             return [

--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -211,6 +211,8 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             this.targetPosition = [0, 0, 0];
         }
         adjustEnvVars(distanceToTarget) {
+            // places new tools at the camera's targetPosition...
+            // relies on the fact that new tools are dropped 400mm in front of camera by default
             realityEditor.device.environment.variables.newFrameDistanceMultiplier = distanceToTarget / 400;
         }
         getTargetMatrix() {


### PR DESCRIPTION
In combination with last week's userinterface PR, this will place tools at the camera focus point (the little blue dot that you orbit around) if it doesn't find a suitable projected location on the area target mesh. Old method was very haphazard and could place tools at an unpredictable distance from camera.