### PR TITLE
mute/unmute implementation for remote operator by intercepting appFunctionCall for mute/unmute

### DIFF
--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -914,6 +914,16 @@ void main() {
             this.webRTCCoordinator = new realityEditor.device.cameraVis.WebRTCCoordinator(this, ws, network);
         }
 
+        muteMicrophone() {
+            if (!this.webRTCCoordinator) return;
+            this.webRTCCoordinator.mute();
+        }
+
+        unmuteMicrophone() {
+            if (!this.webRTCCoordinator) return;
+            this.webRTCCoordinator.unmute();
+        }
+
         renderPointCloud(id, textureKey, imageUrl) {
             if (!this.cameras[id]) {
                 this.createCameraVis(id);

--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -409,6 +409,14 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
                 break;
                 // case 'getUDPMessages':
                 //     getUDPMessages(messageBody.callback);
+            case 'muteMicrophone':
+                console.log('mute remote operator');
+                realityEditor.gui.ar.desktopRenderer.muteMicrophoneForCameraVis();
+                break;
+            case 'unmuteMicrophone':
+                console.log('unmute remote operator');
+                realityEditor.gui.ar.desktopRenderer.unmuteMicrophoneForCameraVis();
+                break;
             default:
                 // console.log('could not find desktop implementation of app.' + messageBody.functionName);
                 return;

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -498,5 +498,18 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
         }
     }
 
+    function muteMicrophoneForCameraVis() {
+        if (!cameraVisCoordinator) return;
+        cameraVisCoordinator.muteMicrophone();
+    }
+
+    function unmuteMicrophoneForCameraVis() {
+        if (!cameraVisCoordinator) return;
+        cameraVisCoordinator.unmuteMicrophone();
+    }
+
+    exports.muteMicrophoneForCameraVis = muteMicrophoneForCameraVis;
+    exports.unmuteMicrophoneForCameraVis = unmuteMicrophoneForCameraVis;
+
     realityEditor.addons.addCallback('init', initService);
 })(realityEditor.gui.ar.desktopRenderer);


### PR DESCRIPTION
Feels a bit indirect to access the webRTCCoordinator this way, but this seems to work