### PR TITLE
Properly set primaryWorld based on ?world query item

### DIFF
--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -114,6 +114,11 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
         restyleForDesktop();
         modifyGlobalNamespace();
 
+        let worldIdQueryItem = getPrimaryWorldId();
+        if (worldIdQueryItem) {
+            realityEditor.network.discovery.setPrimaryWorld(null, worldIdQueryItem);
+        }
+
         function setupMenuBarWhenReady() {
             if (realityEditor.gui.setupMenuBar) {
                 realityEditor.gui.setupMenuBar();
@@ -528,19 +533,6 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
 
                 if (typeof realityEditor.network.discovery !== 'undefined') {
                     realityEditor.network.discovery.processHeartbeat(msgContent);
-                }
-
-                let primaryWorldId = getPrimaryWorldId();
-                if (!primaryWorldId) {
-                    realityEditor.network.addHeartbeatObject(msgContent);
-                } else {
-                    getUndownloadedObjectWorldId(msgContent).then(worldId => {
-                        if (worldId === primaryWorldId) {
-                            realityEditor.network.addHeartbeatObject(msgContent);
-                        } else {
-                            console.log('ignored object because of mismatching worldId');
-                        }
-                    });
                 }
             }
 


### PR DESCRIPTION
Didn't realize this was only half-implemented and probably led to performance issues on remote operator, as many worlds would all load in even tho only the primary world's mesh would render.