### PR TITLE
adds a constant to set an increased connection timeout for the cameraVis

### DIFF
--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -13,6 +13,7 @@ import { SpaghettiMeshPath } from '../../src/humanPose/spaghetti.js';
     const DEPTH_REPR_PNG = false;
     const DEPTH_WIDTH = 256;
     const DEPTH_HEIGHT = 144;
+    const CONNECTION_TIMEOUT_MS = 10000;
     const PATCH_KEY_PREFIX = 'realityEditor.device.cameraVis.patch';
     const PROXY = /(\w+\.)?toolboxedge.net/.test(window.location.host);
     const ShaderMode = {
@@ -809,7 +810,7 @@ void main() {
                     camera.mesh.visible = false;
                     continue;
                 }
-                if (now - camera.lastUpdate > 5000) {
+                if (now - camera.lastUpdate > CONNECTION_TIMEOUT_MS) {
                     camera.remove();
                     delete this.cameras[camera.id];
                     this.callbacks.onCameraVisRemoved.forEach(cb => {


### PR DESCRIPTION
On slow networks, the cameraVis cameras reset to origin and their pointclouds disappear if they didn't receive an update in the last 5 seconds. I'm sure there's a better solution overall to make the connection more reliable, but for now we could increase the timeout value if you want to minimize this.