### PR TITLE
Remote operator off-center camera

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -78,6 +78,10 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 onScaleToggled: [],
                 onStopFollowing: [] // other modules can discover when pan/rotate forced this camera out of follow mode
             };
+
+            this.normalModePrompt = null;
+            this.flyModePrompt = null;
+            this.addFlyAndNormalModePrompts();
             
             this.focusTargetCube = null;
             this.addFocusTargetCube();
@@ -97,6 +101,33 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 );
                 this.focusTargetCube.position.copy(new THREE.Vector3().fromArray(this.mouseInput.lastWorldPos));
                 realityEditor.gui.threejsScene.addToScene(this.focusTargetCube);
+            }
+        }
+        addFlyAndNormalModePrompts() {
+            // add normal mode prompt
+            this.normalModePrompt = document.createElement('div');
+            this.normalModePrompt.classList.add('mode-prompt');
+            this.normalModePrompt.style.top = `${realityEditor.device.environment.variables.screenTopOffset}`;
+            this.normalModePrompt.innerHTML = 'Entered normal mode';
+            document.body.appendChild(this.normalModePrompt);
+            // add fly mode prompt
+            this.flyModePrompt = document.createElement('div');
+            this.flyModePrompt.classList.add('mode-prompt', 'fly-mode-prompt');
+            this.flyModePrompt.style.top = `${realityEditor.device.environment.variables.screenTopOffset}`;
+            this.flyModePrompt.innerHTML = 'Entered fly mode';
+            document.body.appendChild(this.flyModePrompt);
+        }
+        switchMode() {
+            if (this.isFlying) {
+                this.flyModePrompt.classList.add('mode-prompt-disappear');
+                this.flyModePrompt.classList.remove('mode-prompt-disappear');
+                this.flyModePrompt.classList.add('mode-prompt-appear');
+                this.normalModePrompt.classList.add('mode-prompt-disappear');
+            } else {
+                this.normalModePrompt.classList.add('mode-prompt-disappear');
+                this.normalModePrompt.classList.remove('mode-prompt-disappear');
+                this.normalModePrompt.classList.add('mode-prompt-appear');
+                this.flyModePrompt.classList.add('mode-prompt-disappear');
             }
         }
         addEventListeners() {
@@ -207,6 +238,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 if (e.key === 'f' || e.key === 'F') {
                     this.isFlying = !this.isFlying;
                     this.mouseFlyInput.justSwitched = true;
+                    this.switchMode();
                     console.log(this.isFlying?'fly mode activate':'normal mode activate');
                 }
             });

--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -457,6 +457,11 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                         let percentToClipBy = 0.5 * this.distanceToTarget / magnitude(vector);
                         vector = scalarMultiply(vector, percentToClipBy);
                     }
+                    // if distanceToTarget <= 200, slow down zooming speed to prevent from zooming too close
+                    if (isZoomingIn && this.distanceToTarget <= 200) {
+                        let scrollFactor = Math.pow(this.distanceToTarget / 200, 2);
+                        vector = scalarMultiply(vector, scrollFactor);
+                    }
                     // * 0.7 to prevent the camera from getting too close to the camera target point
                     this.velocity = add(this.velocity, scalarMultiply(vector, 0.7));
 

--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -107,27 +107,46 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             // add normal mode prompt
             this.normalModePrompt = document.createElement('div');
             this.normalModePrompt.classList.add('mode-prompt');
-            this.normalModePrompt.style.top = `${realityEditor.device.environment.variables.screenTopOffset}`;
-            this.normalModePrompt.innerHTML = 'Entered normal mode';
+            this.normalModePrompt.style.top = (realityEditor.device.environment.variables.screenTopOffset + 20) + 'px';
+            let normalModeText = document.createElement('div');
+            normalModeText.classList.add('mode-prompt-big-font');
+            normalModeText.innerHTML = 'Entered normal mode';
+            this.normalModePrompt.appendChild(normalModeText);
+            this.normalModePrompt.appendChild(document.createElement('br'));
+            let normalModeControls1 = document.createElement('div');
+            normalModeControls1.innerHTML = 'F - switch mode, RMB - rotate,';
+            this.normalModePrompt.appendChild(normalModeControls1);
+            let normalModeControls2 = document.createElement('div');
+            normalModeControls2.innerHTML = 'MMB/RMB+Alt - pan, scroll wheel - zoom';
+            this.normalModePrompt.appendChild(normalModeControls2);
             document.body.appendChild(this.normalModePrompt);
+            setTimeout(() => {this.normalModePrompt.style.opacity = 0}, 3000);
             // add fly mode prompt
             this.flyModePrompt = document.createElement('div');
             this.flyModePrompt.classList.add('mode-prompt', 'fly-mode-prompt');
-            this.flyModePrompt.style.top = `${realityEditor.device.environment.variables.screenTopOffset}`;
-            this.flyModePrompt.innerHTML = 'Entered fly mode';
+            this.flyModePrompt.style.top = (realityEditor.device.environment.variables.screenTopOffset + 20) + 'px';
+            let flyModeText = document.createElement('div');
+            flyModeText.classList.add('mode-prompt-big-font');
+            flyModeText.innerHTML = 'Entered fly mode';
+            this.flyModePrompt.appendChild(flyModeText);
+            this.flyModePrompt.appendChild(document.createElement('br'));
+            let flyModeControls1 = document.createElement('div');
+            flyModeControls1.innerHTML = 'F - switch mode, W/A/S/D - move,';
+            this.flyModePrompt.appendChild(flyModeControls1);
+            let flyModeControls2 = document.createElement('div');
+            flyModeControls2.innerHTML = 'Q/E - down/up, SHIFT - speed up';
+            this.flyModePrompt.appendChild(flyModeControls2);
             document.body.appendChild(this.flyModePrompt);
         }
         switchMode() {
             if (this.isFlying) {
-                this.flyModePrompt.classList.add('mode-prompt-disappear');
-                this.flyModePrompt.classList.remove('mode-prompt-disappear');
-                this.flyModePrompt.classList.add('mode-prompt-appear');
-                this.normalModePrompt.classList.add('mode-prompt-disappear');
+                this.normalModePrompt.style.opacity = '0';
+                this.flyModePrompt.style.opacity = '1';
+                setTimeout(() => {this.flyModePrompt.style.opacity = 0}, 2000);
             } else {
-                this.normalModePrompt.classList.add('mode-prompt-disappear');
-                this.normalModePrompt.classList.remove('mode-prompt-disappear');
-                this.normalModePrompt.classList.add('mode-prompt-appear');
-                this.flyModePrompt.classList.add('mode-prompt-disappear');
+                this.flyModePrompt.style.opacity = '0';
+                this.normalModePrompt.style.opacity = '1';
+                setTimeout(() => {this.normalModePrompt.style.opacity = 0}, 2000);
             }
         }
         addEventListeners() {
@@ -237,37 +256,19 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             document.addEventListener('keypress', (e) => {
                 if (e.key === 'f' || e.key === 'F') {
                     this.isFlying = !this.isFlying;
-                    this.mouseFlyInput.justSwitched = true;
                     this.switchMode();
-                    console.log(this.isFlying?'fly mode activate':'normal mode activate');
+                    if (this.isFlying) {
+                        document.body.requestPointerLock();
+                    } else {
+                        document.exitPointerLock();
+                    }
                 }
             });
 
             document.addEventListener('pointermove', function (event) {
-                if (this.isFlying) {
-                    // justSwitched stays true for one frame before becoming false
-                    // to prevent x,y offsets being too big and suddenly shifts the camera lookAt position
-                    if (this.mouseFlyInput.justSwitched) {
-                        this.mouseFlyInput.last.x = event.pageX;
-                        this.mouseFlyInput.last.y = event.pageY;
-
-                        let xOffset = event.pageX - this.mouseFlyInput.last.x;
-                        let yOffset = event.pageY - this.mouseFlyInput.last.y;
-                        
-                        this.mouseFlyInput.unprocessedDX = xOffset;
-                        this.mouseFlyInput.unprocessedDY = yOffset;
-
-                        this.mouseFlyInput.justSwitched = false;
-                    } else {
-                        let xOffset = event.pageX - this.mouseFlyInput.last.x;
-                        let yOffset = event.pageY - this.mouseFlyInput.last.y;
-
-                        this.mouseFlyInput.unprocessedDX = xOffset;
-                        this.mouseFlyInput.unprocessedDY = yOffset;
-
-                        this.mouseFlyInput.last.x = event.pageX;
-                        this.mouseFlyInput.last.y = event.pageY;
-                    }
+                if ( document.pointerLockElement === document.body ) {
+                    this.mouseFlyInput.unprocessedDX = event.movementX;
+                    this.mouseFlyInput.unprocessedDY = event.movementY;
                 } else {
                     if (this.mouseInput.isPointerDown) {
 
@@ -539,7 +540,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 let keyDirection = [transformKeys.S - transformKeys.W, transformKeys.D - transformKeys.A, transformKeys.E - transformKeys.Q];
                 if (magnitude(keyDirection) !== 0) {
                     let vector = [0, 0, 0];
-                    flyingSpeed = this.keyboard.keyStates[this.keyboard.keyCodes.SHIFT] === 'down' ? 60 : 30;
+                    flyingSpeed = this.keyboard.keyStates[this.keyboard.keyCodes.SHIFT] === 'down' ? 40 : 20;
                     let forwardValue = scalarMultiply(forwardVector, keyDirection[0]);
                     let horizontalValue = scalarMultiply(horizontalVector, keyDirection[1]);
                     let verticalValue = scalarMultiply([0, 1, 0], keyDirection[2]);

--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -26,6 +26,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 this.initialPosition = [initialPosition[0], initialPosition[1], initialPosition[2]];
                 this.position = [initialPosition[0], initialPosition[1], initialPosition[2]];
             }
+            this.initialDistance = magnitude(this.position);
             this.targetPosition = [0, 0, 0];
             this.velocity = [0, 0, 0];
             this.targetVelocity = [0, 0, 0];
@@ -44,9 +45,11 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 unprocessedScroll: 0,
                 isPointerDown: false,
                 isRightClick: false,
+                isRotateRequested: false,
                 isStrafeRequested: false,
                 first: { x: 0, y: 0 },
-                last: { x: 0, y: 0 }
+                last: { x: 0, y: 0 },
+                lastWorldPos: [0, 0, 0],
             };
             this.mouseFlyInput = {
                 justSwitched: true,
@@ -76,6 +79,8 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 onStopFollowing: [] // other modules can discover when pan/rotate forced this camera out of follow mode
             };
             this.addEventListeners();
+
+            this.focusTargetCube = null;
 
             this.threeJsContainer = new THREE.Group();
             this.threeJsContainer.name = 'VirtualCamera_' + cameraNode.id + '_threeJsContainer';
@@ -112,12 +117,15 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 if (event.button === 2 || event.button === 1) { // 2 is right click, 0 is left, 1 is middle button
                     this.mouseInput.isPointerDown = true;
                     this.mouseInput.isRightClick = false;
+                    this.mouseInput.isRotateRequested = false;
                     this.mouseInput.isStrafeRequested = false;
                     if (event.button === 1 || this.keyboard.keyStates[this.keyboard.keyCodes.ALT] === 'down') {
                         this.mouseInput.isStrafeRequested = true;
                         this.triggerPanCallbacks(true);
                     } else if (event.button === 2) {
+                        setFocusTargetCube(event);
                         this.mouseInput.isRightClick = true;
+                        this.mouseInput.isRotateRequested = true;
                         this.triggerRotateCallbacks(true);
                         if (!this.followingState.active) { // we preserve distance to virtualizer if following, not distance to target
                             this.preRotateDistanceToTarget = this.distanceToTarget;
@@ -131,15 +139,40 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 }
             }.bind(this));
 
+            // when in normal mode, right click to add a green focus cube to the scene
+            const setFocusTargetCube = (event) => {
+                if (this.isFlying) return;
+                // conform to spatial cursor mousemove event pageX and pageY
+                if (event.button === 2) {
+                    let worldIntersectPoint = realityEditor.spatialCursor.getRaycastCoordinates(event.pageX, event.pageY).point;
+                    if (worldIntersectPoint === undefined) return;
+                    // record pointerdown world intersect point, for off-center camera rotation
+                    this.mouseInput.lastWorldPos = [worldIntersectPoint.x, worldIntersectPoint.y, worldIntersectPoint.z];
+                    if (this.focusTargetCube === null) {
+                        this.focusTargetCube = new THREE.Mesh(
+                            new THREE.BoxGeometry(20, 20, 20),
+                            new THREE.MeshBasicMaterial({color: 0x00ff00})
+                        );
+                        this.focusTargetCube.position.copy(worldIntersectPoint);
+                        realityEditor.gui.threejsScene.addToScene(this.focusTargetCube);
+                    } else {
+                        this.focusTargetCube.position.copy(worldIntersectPoint);
+                    }
+                }
+            };
+
             const pointerReset = () => {
                 this.mouseInput.isPointerDown = false;
                 this.mouseInput.isRightClick = false;
+                this.mouseInput.isRotateRequested = false;
                 this.mouseInput.isStrafeRequested = false;
+
+                this.mouseInput.first.x = 0;
+                this.mouseInput.first.y = 0;
                 this.mouseInput.last.x = 0;
                 this.mouseInput.last.y = 0;
 
                 if (this.preRotateDistanceToTarget !== null) {
-                    this.zoomBackToPreRotateLevel();
                     this.preRotateDistanceToTarget = null;
                 }
 
@@ -150,6 +183,13 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 
             document.addEventListener('pointerup', pointerReset);
             document.addEventListener('pointercancel', pointerReset);
+
+            // focus camera on the focus point
+            document.addEventListener('keypress', function (e) {
+                if (e.key === 'g' || e.key === 'G') {
+                    this.focus(this.focusTargetCube.position.clone());
+                }
+            }.bind(this));
 
             // enter fly mode
             document.addEventListener('keypress', (e) => {
@@ -241,13 +281,6 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         triggerScaleCallbacks(newValue) {
             this.callbacks.onScaleToggled.forEach(function(cb) { cb(newValue); });
         }
-        // there is a small bug with orbiting the camera that causes it to drift further away if you go too fast
-        // this locks it at the correct zoom level unless you intentionally scroll while rotating
-        zoomBackToPreRotateLevel() {
-            if (this.preRotateDistanceToTarget === null) { return; }
-            let cameraNormalizedVector = normalize(add(this.position, negate(this.targetPosition)));
-            this.position = add(this.targetPosition, scalarMultiply(cameraNormalizedVector, this.preRotateDistanceToTarget));
-        }
         zoomBackToPreStopFollowLevel() {
             if (this.preStopFollowingDistanceToTarget === null) { return; }
             let cameraNormalizedVector = normalize(add(this.position, negate(this.targetPosition)));
@@ -255,6 +288,55 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         }
         onStopFollowing(callback) {
             this.callbacks.onStopFollowing.push(callback);
+        }
+        // get the camera direction as an array
+        getCameraDirection() {
+            return normalize(sub(this.targetPosition, this.position));
+        }
+        // if specify a focus direction, the camera will look into that direction. Note that dir is expected to be a unit vector
+        // if not, move the camera while keeping its lookAt direction
+        focus(pos, dir) {
+            let zoomFactor = 4000;
+            this.targetPosition[0] = pos.x;
+            this.targetPosition[1] = pos.y;
+            this.targetPosition[2] = pos.z;
+            if (dir !== undefined) {
+                this.position[0] = this.targetPosition[0] + dir.x * zoomFactor;
+                this.position[1] = this.targetPosition[1] + dir.y * zoomFactor;
+                this.position[2] = this.targetPosition[2] + dir.z * zoomFactor;
+            } else {
+                let camDir = this.getCameraDirection();
+                this.position[0] = this.targetPosition[0] - camDir[0] * zoomFactor;
+                this.position[1] = this.targetPosition[1] - camDir[1] * zoomFactor;
+                this.position[2] = this.targetPosition[2] - camDir[2] * zoomFactor;
+            }
+        }
+        orbit(xRot, yRot, camPos, camLookAt, target) {
+            const yaxis = new THREE.Vector3(0, 1, 0);
+            const newXAxis = new THREE.Vector3();
+            // basically set newXAxis x and z to direction tangent to camera lookAt direction, and y to 0
+            newXAxis.x = -camLookAt.z;
+            newXAxis.z = camLookAt.x;
+            newXAxis.y = 0;
+            
+            newXAxis.normalize();
+
+            // step 1: first change the camera position
+            // method 1: 
+            const newCamPos = camPos
+                .sub(target)
+                .applyAxisAngle(newXAxis, xRot)
+                .applyAxisAngle(yaxis, yRot)
+                .add(target);
+            this.position = newCamPos.toArray();
+
+            // step 2: change the camera lookAt/target position
+            const relLookAt = camLookAt
+                .multiplyScalar(this.initialDistance)
+                .applyAxisAngle(newXAxis, xRot)
+                .applyAxisAngle(yaxis, yRot)
+                .add(newCamPos);
+            this.targetPosition = relLookAt.toArray();
         }
         // this needs to be called externally each frame that you want it to update
         update() {
@@ -287,7 +369,57 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             let horizontalVector = normalize(crossProduct(uv, forwardVector)); // a "right" vector, orthogonal to n and the lookup vector
             let verticalVector = crossProduct(forwardVector, horizontalVector); // resulting orthogonal vector to n and u, as the up vector isn't necessarily one anymore
 
-            if (this.mouseInput.unprocessedScroll !== 0) {
+            let distancePanFactor = Math.max(1, this.distanceToTarget / 1000); // speed when 1 meter units away, scales up w/ distance
+
+            if (this.idleOrbitting) {
+                this.mouseInput.unprocessedDX = 0.3;
+                this.mouseInput.isStrafeRequested = false;
+            }
+
+            // rotate
+            if (this.mouseInput.isRotateRequested && (this.mouseInput.unprocessedDX !== 0 || this.mouseInput.unprocessedDY !== 0)) {
+                let xRot = -this.mouseInput.unprocessedDY * 0.01;
+                let yRot = -this.mouseInput.unprocessedDX * 0.01;
+                let camPos = new THREE.Vector3().fromArray(this.position);
+                let camLookAt = new THREE.Vector3().fromArray(this.getCameraDirection());
+                let target = new THREE.Vector3().fromArray(this.mouseInput.lastWorldPos);
+                this.orbit(xRot, yRot, camPos, camLookAt, target);
+
+                this.deselectTarget();
+                
+                this.mouseInput.unprocessedDX = 0;
+                this.mouseInput.unprocessedDY = 0;
+            }
+
+            // strafe
+            if (this.mouseInput.isStrafeRequested) {
+                if (this.mouseInput.unprocessedDX !== 0) { // strafe left-right
+                    let vector = scalarMultiply(negate(horizontalVector), distancePanFactor * this.speedFactors.translation * this.mouseInput.unprocessedDX * getCameraPanSensitivity());
+                    this.targetVelocity = add(this.targetVelocity, vector);
+                    this.velocity = add(this.velocity, vector);
+                    this.deselectTarget();
+
+                    this.mouseInput.unprocessedDX = 0;
+                }
+                if (this.mouseInput.unprocessedDY !== 0) { // strafe up-down
+                    let vector = scalarMultiply(verticalVector, distancePanFactor * this.speedFactors.translation * this.mouseInput.unprocessedDY * getCameraPanSensitivity());
+                    this.targetVelocity = add(this.targetVelocity, vector);
+                    this.velocity = add(this.velocity, vector);
+                    this.deselectTarget();
+
+                    this.mouseInput.unprocessedDY = 0;
+                }
+            }
+
+            // scroll
+            scrollOperation: if (this.mouseInput.unprocessedScroll !== 0) {
+                
+                // prevent from scrolling while rotating
+                if (this.mouseInput.isRotateRequested) {
+                    this.mouseInput.unprocessedScroll = 0;
+                    this.deselectTarget();
+                    break scrollOperation;
+                }
 
                 if (this.followingState.active) {
                     // while following, zooming in-out moves the camera along a parametric curve up and behind the virtualizer
@@ -299,10 +431,10 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 } else {
                     // increase speed as distance increases
                     let nonLinearFactor = 1.05; // closer to 1 = less intense log (bigger as distance bigger)
+                    
+                    // interpolate camera towards camera target point
                     let distanceMultiplier = Math.max(1, getBaseLog(nonLinearFactor, this.distanceToTarget) / 100);
-
                     let vector = scalarMultiply(forwardVector, distanceMultiplier * this.speedFactors.scale * getCameraZoomSensitivity() * this.mouseInput.unprocessedScroll);
-
                     // prevent you from zooming beyond it
                     let isZoomingIn = this.mouseInput.unprocessedScroll < 0;
                     if (isZoomingIn && this.distanceToTarget <= magnitude(vector)) {
@@ -310,49 +442,28 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                         let percentToClipBy = 0.5 * this.distanceToTarget / magnitude(vector);
                         vector = scalarMultiply(vector, percentToClipBy);
                     }
+                    // * 0.7 to prevent the camera from getting too close to the camera target point
+                    this.velocity = add(this.velocity, scalarMultiply(vector, 0.7));
 
-                    this.velocity = add(this.velocity, vector);
+                    // interpolate camera target point towards focus point
+                    let offset = sub(this.mouseInput.lastWorldPos, this.targetPosition);
+                    let targetToFocus = magnitude(offset);
+                    if (targetToFocus <= 300) {
+                        this.targetPosition = this.mouseInput.lastWorldPos;
+                        this.mouseInput.unprocessedScroll = 0;
+                        this.deselectTarget();
+                        break scrollOperation;
+                    }
+                    // * 0.3 to make distanceMultiplier2 smaller for the camera target to focus point interpolation, to avoid overshooting
+                    let distanceMultiplier2 = -Math.max(1, getBaseLog(nonLinearFactor, targetToFocus) / 100) * 0.3;
+                    let targetForwardVector = normalize(offset);
+                    let vector2 = scalarMultiply(targetForwardVector, distanceMultiplier2 * this.speedFactors.scale * getCameraZoomSensitivity() * this.mouseInput.unprocessedScroll);
+                    this.targetVelocity = add(this.targetVelocity, vector2);
+                    
                     this.deselectTarget();
                 }
 
                 this.mouseInput.unprocessedScroll = 0; // reset now that data is processed
-            }
-
-            let distancePanFactor = Math.max(1, this.distanceToTarget / 1000); // speed when 1 meter units away, scales up w/ distance
-
-            if (this.idleOrbitting) {
-                this.mouseInput.unprocessedDX = 0.3;
-                this.mouseInput.isStrafeRequested = false;
-            }
-
-            if (this.mouseInput.unprocessedDX !== 0) {
-                if (this.mouseInput.isStrafeRequested) { // strafe left-right
-                    let vector = scalarMultiply(negate(horizontalVector), distancePanFactor * this.speedFactors.translation * this.mouseInput.unprocessedDX * getCameraPanSensitivity());
-                    this.targetVelocity = add(this.targetVelocity, vector);
-                    this.velocity = add(this.velocity, vector);
-                    this.deselectTarget();
-                } else { // rotate
-                    let vector = scalarMultiply(negate(vCamX), this.speedFactors.rotation * getCameraRotateSensitivity() * (2 * Math.PI * this.distanceToTarget) * this.mouseInput.unprocessedDX);
-                    this.velocity = add(this.velocity, vector);
-                    this.deselectTarget();
-                }
-
-                this.mouseInput.unprocessedDX = 0;
-            }
-
-            if (this.mouseInput.unprocessedDY !== 0) {
-                if (this.mouseInput.isStrafeRequested) { // stafe up-down
-                    let vector = scalarMultiply(verticalVector, distancePanFactor * this.speedFactors.translation * this.mouseInput.unprocessedDY * getCameraPanSensitivity());
-                    this.targetVelocity = add(this.targetVelocity, vector);
-                    this.velocity = add(this.velocity, vector);
-                    this.deselectTarget();
-                } else { // rotate
-                    let vector = scalarMultiply(vCamY, this.speedFactors.rotation * getCameraRotateSensitivity() * (2 * Math.PI * this.distanceToTarget) * this.mouseInput.unprocessedDY);
-                    this.velocity = add(this.velocity, vector);
-                    this.deselectTarget();
-                }
-
-                this.mouseInput.unprocessedDY = 0;
             }
 
             let flyingSpeed = 30;
@@ -402,8 +513,13 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             const LOWER_ANGLE = Math.PI * 0.2; // soft lower bound
             if (verticalAngle > LOWER_ANGLE && verticalAngle < UPPER_ANGLE) {
                 // if within soft bounds, move the camera as usual
-                this.position = add(this.position, this.velocity);
-                this.targetPosition = add(this.targetPosition, this.targetVelocity);
+                if (this.mouseInput.isRotateRequested) {
+                    this.position = addButKeepDistance(this.position, this.velocity, this.mouseInput.lastWorldPos);
+                    this.targetPosition = addButKeepDistance(this.targetPosition, this.targetVelocity, this.mouseInput.lastWorldPos);
+                } else {
+                    this.position = add(this.position, this.velocity);
+                    this.targetPosition = add(this.targetPosition, this.targetVelocity);
+                }
             } else {
                 // if between soft bounds and top or bottom, slow movement exponentially as angle approaches 0 or PI
                 // e.g. if angle is PI * 0.85, we are 25% between UPPER_ANGLE and PI, so slow down by 0.25^2 = 6%
@@ -411,13 +527,13 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 // e.g. if angle is PI * 0.99, we are 95% between UPPER_ANGLE and PI, so slow down by 0.95^2 = 90%
                 let closenessToAbsoluteBorder = (verticalAngle > Math.PI / 2) ? ((verticalAngle - UPPER_ANGLE) / (Math.PI - UPPER_ANGLE)) : ((verticalAngle - LOWER_ANGLE) / (0 - LOWER_ANGLE));
                 let scaleFactor = Math.pow(1 - closenessToAbsoluteBorder, 2);
-                this.position = add(this.position, scalarMultiply(this.velocity, scaleFactor));
-                this.targetPosition = add(this.targetPosition, scalarMultiply(this.targetVelocity, scaleFactor));
-            }
-
-            // if rotating, and distance has drifted without intentionally zooming, reset back to correct distance
-            if (this.preRotateDistanceToTarget && Math.abs(this.preRotateDistanceToTarget - this.distanceToTarget) > 10) {
-                this.zoomBackToPreRotateLevel();
+                if (this.mouseInput.isRotateRequested) {
+                    this.position = addButKeepDistance(this.position, scalarMultiply(this.velocity, scaleFactor), this.mouseInput.lastWorldPos);
+                    this.targetPosition = addButKeepDistance(this.targetPosition, scalarMultiply(this.targetVelocity, scaleFactor), this.mouseInput.lastWorldPos);
+                } else {
+                    this.position = add(this.position, scalarMultiply(this.velocity, scaleFactor));
+                    this.targetPosition = add(this.targetPosition, scalarMultiply(this.targetVelocity, scaleFactor));
+                }
             }
 
             // tween the matrix every frame to animate it to the new position
@@ -705,8 +821,29 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 
     //************************************************ Utilities *************************************************//
 
+    // since groundPlaneMatrix is applied to threejsContainerObj in threejsScene.js
+    // here we apply the same groundPlaneMatrix to VirtualCamera, so that it's in the same coord space as threejsContainerObj
+    function convertToThreejsContainerObjSpace(eyeX, eyeY, eyeZ, centerX, centerY, centerZ) {
+        let groundPlaneMatrixArray = realityEditor.sceneGraph.getGroundPlaneNode().worldMatrix;
+        let groundPlaneMatrix = new THREE.Matrix4();
+        realityEditor.gui.threejsScene.setMatrixFromArray(groundPlaneMatrix, groundPlaneMatrixArray);
+        let cameraPos = new THREE.Vector3(eyeX, eyeY, eyeZ);
+        cameraPos.applyMatrix4(groundPlaneMatrix);
+        eyeX = cameraPos.x;
+        eyeY = cameraPos.y;
+        eyeZ = cameraPos.z;
+        let targetPos = new THREE.Vector3(centerX, centerY, centerZ);
+        targetPos.applyMatrix4(groundPlaneMatrix);
+        centerX = targetPos.x;
+        centerY = targetPos.y;
+        centerZ = targetPos.z;
+        return {a: eyeX, b: eyeY, c: eyeZ, d: centerX, e: centerY, f: centerZ};
+    }
+    
     // Working look-at matrix generator (with a set of vector3 math functions)
     function lookAt( eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ ) {
+        let {a, b, c, d, e, f} = convertToThreejsContainerObjSpace(eyeX, eyeY, eyeZ, centerX, centerY, centerZ);
+        eyeX = a; eyeY = b; eyeZ = c; centerX = d; centerY = e; centerZ = f;
         var ev = [eyeX, eyeY, eyeZ];
         var cv = [centerX, centerY, centerZ];
         var uv = [upX, upY, upZ];
@@ -733,6 +870,18 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         return [A[0] + B[0], A[1] + B[1], A[2] + B[2]];
     }
 
+    // specifically used to add velocity to position but unscale position to keep the same distance from position to focus cube position
+    // A - position/targetPosition, v - velocity to add, F - focus cube position
+    function addButKeepDistance(P, v, F) {
+        let offset = sub(P, F);
+        let mag = magnitude(offset);
+        return add(scalarMultiply(normalize(add(offset, v)), mag), F);
+    }
+
+    function sub(A, B) {
+        return add(A, negate(B));
+    }
+
     function hadamardProduct(A, B) {
         return [A[0] * B[0], A[1] * B[1], A[2] * B[2]];
     }
@@ -742,6 +891,8 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     }
 
     function normalize(A) {
+        // include the edge case where A === [0, 0, 0]
+        if (A[0] === 0 && A[1] === 0 && A[2] === 0) return A;
         var mag = magnitude(A);
         return [A[0] / mag, A[1] / mag, A[2] / mag];
     }

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -139,7 +139,8 @@ createNameSpace('realityEditor.device.desktopCamera');
         let cameraNode = realityEditor.sceneGraph.getSceneNodeById('CAMERA');
         virtualCamera = new realityEditor.device.VirtualCamera(cameraNode, 1, 0.001, 10, INITIAL_CAMERA_POSITION, floorOffset);
 
-        cameraTargetElementId = realityEditor.sceneGraph.addVisualElement('cameraTarget', undefined, undefined, virtualCamera.getTargetMatrix());
+        // set cameraTargetElement parent as groundPlaneNode to make the coord space of cameraTargetElement the same as virtual camera and threejsContainerObj
+        cameraTargetElementId = realityEditor.sceneGraph.addVisualElement('cameraTarget', parentNode, undefined, virtualCamera.getTargetMatrix());
 
         virtualCamera.onPanToggled(function(isPanning) {
             if (isPanning && !knownInteractionStates.pan) {
@@ -462,13 +463,13 @@ createNameSpace('realityEditor.device.desktopCamera');
 
     function panToggled() {
         if (cameraTargetIcon) {
-            cameraTargetIcon.visible = knownInteractionStates.pan || knownInteractionStates.rotate || knownInteractionStates.scale;
+            //cameraTargetIcon.visible = knownInteractionStates.pan || knownInteractionStates.rotate || knownInteractionStates.scale;
         }
         updateInteractionCursor(cameraTargetIcon.visible, '/addons/vuforia-spatial-remote-operator-addon/cameraPan.svg');
     }
     function rotateToggled() {
         if (cameraTargetIcon) {
-            cameraTargetIcon.visible = knownInteractionStates.rotate || knownInteractionStates.pan || knownInteractionStates.scale;
+            //cameraTargetIcon.visible = knownInteractionStates.rotate || knownInteractionStates.pan || knownInteractionStates.scale;
         }
         updateInteractionCursor(cameraTargetIcon.visible, '/addons/vuforia-spatial-remote-operator-addon/cameraRotate.svg');
     }

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -463,24 +463,24 @@ createNameSpace('realityEditor.device.desktopCamera');
 
     function panToggled() {
         if (cameraTargetIcon) {
-            //cameraTargetIcon.visible = knownInteractionStates.pan || knownInteractionStates.rotate || knownInteractionStates.scale;
+            cameraTargetIcon.visible = knownInteractionStates.pan || knownInteractionStates.rotate || knownInteractionStates.scale;
         }
         updateInteractionCursor(cameraTargetIcon.visible, '/addons/vuforia-spatial-remote-operator-addon/cameraPan.svg');
     }
     function rotateToggled() {
         if (cameraTargetIcon) {
-            //cameraTargetIcon.visible = knownInteractionStates.rotate || knownInteractionStates.pan || knownInteractionStates.scale;
+            cameraTargetIcon.visible = knownInteractionStates.rotate || knownInteractionStates.pan || knownInteractionStates.scale;
         }
         updateInteractionCursor(cameraTargetIcon.visible, '/addons/vuforia-spatial-remote-operator-addon/cameraRotate.svg');
     }
     function scaleToggled() {
-        // if (cameraTargetIcon) {
-        //     cameraTargetIcon.visible = knownInteractionStates.scale || knownInteractionStates.pan || knownInteractionStates.rotate;
-        // }
-        if (!cameraTargetIcon.visible) {
-            updateInteractionCursor(false);
+        if (cameraTargetIcon) {
+            cameraTargetIcon.visible = knownInteractionStates.scale || knownInteractionStates.pan || knownInteractionStates.rotate;
         }
-        // updateInteractionCursor(cameraTargetIcon.visible, '/addons/vuforia-spatial-remote-operator-cloud-edition/cameraZoom.svg');
+        // if (!cameraTargetIcon.visible) {
+        //     updateInteractionCursor(false);
+        // }
+        updateInteractionCursor(cameraTargetIcon.visible, '/addons/vuforia-spatial-remote-operator-addon/cameraZoom.svg');
     }
     function updateInteractionCursor(visible, imageSrc) {
         interactionCursor.style.display = visible ? 'inline' : 'none';
@@ -539,18 +539,8 @@ createNameSpace('realityEditor.device.desktopCamera');
 
                     const THREE = realityEditor.gui.threejsScene.THREE;
                     if (!cameraTargetIcon && worldId !== realityEditor.worldObjects.getLocalWorldId()) {
-                        cameraTargetIcon = new THREE.Mesh(new THREE.BoxGeometry(20, 20, 20), new THREE.MeshBasicMaterial({color: 0x00ffff})); //new THREE.MeshNormalMaterial()); // THREE.MeshBasicMaterial({color:0xff0000})
-                        cameraTargetIcon.name = 'cameraTargetElement';
-                        cameraTargetIcon.matrixAutoUpdate = false;
+                        cameraTargetIcon = {};
                         cameraTargetIcon.visible = false;
-                        realityEditor.gui.threejsScene.addToScene(cameraTargetIcon, {worldObjectId: worldId}); //{worldObjectId: areaTargetNode.id, occluded: true});
-                    }
-                    if (cameraTargetIcon) {
-                        // move the cameraTargetIcon to the center of the view, but scale it down if we zoom too close so it doesn't become obnoxious
-                        const cursorScale = Math.min(1.0, realityEditor.sceneGraph.getDistanceToCamera(cameraTargetElementId) / 1000);
-                        let limitedScaleCursorMatrix = realityEditor.gui.ar.utilities.copyMatrix(sceneNode.worldMatrix);
-                        [0, 5, 10].forEach(index => limitedScaleCursorMatrix[index] *= cursorScale);
-                        realityEditor.gui.threejsScene.setMatrixFromArray(cameraTargetIcon.matrix, limitedScaleCursorMatrix);
                     }
 
                     if (unityCamera) {

--- a/content_scripts/setupMenuBar.js
+++ b/content_scripts/setupMenuBar.js
@@ -95,7 +95,7 @@ createNameSpace('realityEditor.gui');
         const rzvAdvanceCameraShader = new MenuItem(ITEM.AdvanceCameraShader, { disabled: true }, null);
         menuBar.addItemToMenu(MENU.Camera, rzvAdvanceCameraShader);
 
-        const toggleAnalyticsSettings = new MenuItem(ITEM.ToggleAnalyticsSettings, { shortcutKey: 'E', toggle: true, defaultVal: false }, null);
+        const toggleAnalyticsSettings = new MenuItem(ITEM.ToggleAnalyticsSettings, { toggle: true, defaultVal: false }, null);
         menuBar.addItemToMenu(MENU.History, toggleAnalyticsSettings);
 
         const clonePatch = new MenuItem(ITEM.ClonePatch, { shortcutKey: 'P', disabled: true }, null);

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -148,25 +148,23 @@ body > * {
     position: fixed;
     left: 50vw;
     transform: translateX(-50%);
-    width: 250px;
-    height: 50px;
+    width: 320px;
+    height: 100px;
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 5px;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    font-size: 1.2em;
+    font-size: 1em;
+
+    transition: opacity 0.3s ease;
+}
+
+.mode-prompt-big-font {
+    font-size: 1.5em;
 }
 
 .fly-mode-prompt {
     opacity: 0;
-}
-
-.mode-prompt-appear {
-    opacity: 1;
-    transition: 0.1s ease;
-}
-
-.mode-prompt-disappear {
-    opacity: 0;
-    transition: 0.5s ease;
 }

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -143,3 +143,30 @@ body > * {
     width: 30px;
     text-align: center;
 }
+
+.mode-prompt {
+    position: fixed;
+    left: 50vw;
+    transform: translateX(-50%);
+    width: 250px;
+    height: 50px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.2em;
+}
+
+.fly-mode-prompt {
+    opacity: 0;
+}
+
+.mode-prompt-appear {
+    opacity: 1;
+    transition: 0.1s ease;
+}
+
+.mode-prompt-disappear {
+    opacity: 0;
+    transition: 0.5s ease;
+}


### PR DESCRIPTION
Proudly presenting the new remote operator off-center camera:
1. RMB on the AreaTarget adds a "focus point" green cube, and camera rotates around this off-center focus point
2. MMB pan function remains unchanged
3. Mouse wheel scroll zooms the camera towards the focus point
4. Press G to instantly zoom & focus on the focus point