### PR TITLE
default view frustum cutouts to disabled; toggle in View menu turns on frustum cutouts

### DIFF
--- a/content_scripts/CameraVis.js
+++ b/content_scripts/CameraVis.js
@@ -626,7 +626,9 @@ void main() {
             this.texture.needsUpdate = true;
             this.textureDepth.needsUpdate = true;
 
-            realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(this.id, this.phone.matrixWorld, this.maxDepthMeters);
+            if (this.cutoutViewFrustum) {
+                realityEditor.gui.ar.desktopRenderer.updateAreaGltfForCamera(this.id, this.phone.matrixWorld, this.maxDepthMeters);
+            }
 
             this.hideNearCamera(newMatrix[12], newMatrix[13], newMatrix[14]);
             let localHistoryPoint = new THREE.Vector3( newMatrix[12], newMatrix[13], newMatrix[14]);
@@ -730,6 +732,15 @@ void main() {
             }
         }
 
+        enableFrustumCutout() {
+            this.cutoutViewFrustum = true;
+        }
+
+        disableFrustumCutout() {
+            this.cutoutViewFrustum = false;
+            realityEditor.gui.threejsScene.removeMaterialCullingFrustum(this.id);
+        }
+
         /**
          * @param {THREE.Color} color
          */
@@ -803,6 +814,17 @@ void main() {
 
             realityEditor.gui.getMenuBar().addCallbackToItem(realityEditor.gui.ITEM.UndoPatch, () => {
                 this.undoPatch();
+            });
+
+            realityEditor.gui.getMenuBar().addCallbackToItem(realityEditor.gui.ITEM.CutoutViewFrustums, (toggled) => {
+                this.cutoutViewFrustums = toggled;
+                for (let camera of Object.values(this.cameras)) {
+                    if (toggled) {
+                        camera.enableFrustumCutout();
+                    } else {
+                        camera.disableFrustumCutout();
+                    }
+                }
             });
 
             this.onPointerDown = this.onPointerDown.bind(this);
@@ -1209,7 +1231,11 @@ void main() {
             this.cameras[id].add();
             this.cameras[id].historyMesh.visible = this.spaghettiVisible;
             this.cameras[id].setShaderMode(enabledShaderModes[this.currentShaderModeIndex]);
-
+            if (this.cutoutViewFrustums) {
+                this.cameras[id].enableFrustumCutout();
+            } else {
+                this.cameras[id].disableFrustumCutout();
+            }
             // these menubar shortcuts are disabled by default, enabled when at least one virtualizer connects
             realityEditor.gui.getMenuBar().setItemEnabled(realityEditor.gui.ITEM.PointClouds, true);
             realityEditor.gui.getMenuBar().setItemEnabled(realityEditor.gui.ITEM.SpaghettiMap, true);

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -221,12 +221,6 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
                                 return id !== cameraVis.id;
                             });
                             realityEditor.gui.threejsScene.removeMaterialCullingFrustum(cameraVis.id);
-                            if (gltf && typeof gltf.traverse !== 'undefined') {
-                                gltf.traverse(child => {
-                                    if (!child.material || !child.material.uniforms) return;
-                                    child.material.uniforms[UNIFORMS.numFrustums].value = Math.min(cameraVisFrustums.length, MAX_VIEW_FRUSTUMS);
-                                });
-                            }
                         });
 
                         realityEditor.gui.getMenuBar().addCallbackToItem(realityEditor.gui.ITEM.AdvanceCameraShader, () => {

--- a/content_scripts/setupMenuBar.js
+++ b/content_scripts/setupMenuBar.js
@@ -36,7 +36,8 @@ createNameSpace('realityEditor.gui');
         AdvanceCameraShader: 'Next Camera Lens',
         ToggleAnalyticsSettings: 'Toggle Analytics Settings',
         ToggleHumanPoses: 'Human Poses',
-        DarkMode: 'Dark Mode'
+        DarkMode: 'Dark Mode',
+        CutoutViewFrustums: 'Cut Out 3D Videos'
     });
     exports.ITEM = ITEM;
 
@@ -82,6 +83,9 @@ createNameSpace('realityEditor.gui');
 
         const toggleUnityVirtualizers = new MenuItem(ITEM.UnityVirtualizers, { shortcutKey: 'V', toggle: true, defaultVal: false }, null); // other module can attach a callback later
         menuBar.addItemToMenu(MENU.View, toggleUnityVirtualizers);
+
+        const toggleCutoutViewFrustums = new MenuItem(ITEM.CutoutViewFrustums, { toggle: true, defaultVal: false }, null);
+        menuBar.addItemToMenu(MENU.View, toggleCutoutViewFrustums);
 
         const toggleSurfaceAnchors = new MenuItem(ITEM.SurfaceAnchors, { shortcutKey: 'SEMICOLON', toggle: true, defaultVal: false }, null); // other module can attach a callback later
         menuBar.addItemToMenu(MENU.View, toggleSurfaceAnchors);


### PR DESCRIPTION
Couldn't bring myself to remove them entirely, but defaults the frustum cutouts to not be active, and adds a menu item to turn it on

Requires https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/418