### PR TITLE
Mobile remote operator

### DIFF
--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -85,9 +85,34 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
         if (!env) {
             env = realityEditor.device.environment.variables; // ensure that this alias is set correctly if loaded too fast
         }
+        
+        if (!realityEditor.device.environment.isDesktop()) {
+            // document.body.style.overscrollBehaviorY = 'contain';
+            // document.body.style.overscrollBehavior = 'none';
+            // document.body.style.overflow = 'hidden';
+            // body {
+            //     overscroll-behavior-y: contain;
+            // }
+
+            // // Disable "pull to refresh" on touchstart event
+            // document.addEventListener('touchstart', function (event) {
+            //     const isScrollable = event.target.scrollHeight > event.target.clientHeight;
+            //     if (!isScrollable) {
+            //         event.preventDefault();
+            //     }
+            // });
+            //
+            // // Disable "pull to refresh" on touchmove event
+            // document.addEventListener('touchmove', function (event) {
+            //     // Check if the touch event is targeting the body element or an element inside it
+            //     if (event.target === document.body || event.target.closest('body')) {
+            //         event.preventDefault();
+            //     }
+            // });
+        }
 
         // Set the correct environment variables so that this add-on changes the app to run in desktop mode
-        env.requiresMouseEvents = true; // this fixes touch events to become mouse events
+        env.requiresMouseEvents = realityEditor.device.environment.isDesktop(); // this fixes touch events to become mouse events
         env.supportsDistanceFading = false; // this prevents things from disappearing when the camera zooms out
         env.ignoresFreezeButton = true; // no need to "freeze the camera" on desktop
         env.shouldDisplayLogicMenuModally = true; // affects appearance of crafting board

--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -80,7 +80,7 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
     function initService() {
         // by including this check, we can tolerate compiling this add-on into the app without breaking everything
         // (ideally this add-on should only be added to a "desktop" server but this should effectively ignore it on mobile)
-        if (!realityEditor.device.environment.isDesktop()) { return; }
+        if (realityEditor.device.environment.isARMode()) { return; }
 
         if (!env) {
             env = realityEditor.device.environment.variables; // ensure that this alias is set correctly if loaded too fast
@@ -416,6 +416,10 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
      * @todo Needs to be manually modified as more native calls are added. Add one switch case per native app call.
      */
     function modifyGlobalNamespace() {
+        
+        // mark that we've manipulated the webkit reference, so that we
+        // can still detect isWithinToolboxApp vs running in mobile browser
+        window.webkitProxy = true;
 
         // set up object structure if it doesn't exist yet
         window.webkit = {

--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -85,31 +85,6 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
         if (!env) {
             env = realityEditor.device.environment.variables; // ensure that this alias is set correctly if loaded too fast
         }
-        
-        if (!realityEditor.device.environment.isDesktop()) {
-            // document.body.style.overscrollBehaviorY = 'contain';
-            // document.body.style.overscrollBehavior = 'none';
-            // document.body.style.overflow = 'hidden';
-            // body {
-            //     overscroll-behavior-y: contain;
-            // }
-
-            // // Disable "pull to refresh" on touchstart event
-            // document.addEventListener('touchstart', function (event) {
-            //     const isScrollable = event.target.scrollHeight > event.target.clientHeight;
-            //     if (!isScrollable) {
-            //         event.preventDefault();
-            //     }
-            // });
-            //
-            // // Disable "pull to refresh" on touchmove event
-            // document.addEventListener('touchmove', function (event) {
-            //     // Check if the touch event is targeting the body element or an element inside it
-            //     if (event.target === document.body || event.target.closest('body')) {
-            //         event.preventDefault();
-            //     }
-            // });
-        }
 
         // Set the correct environment variables so that this add-on changes the app to run in desktop mode
         env.requiresMouseEvents = realityEditor.device.environment.isDesktop(); // this fixes touch events to become mouse events
@@ -444,7 +419,7 @@ window.DEBUG_DISABLE_DROPDOWNS = false;
         
         // mark that we've manipulated the webkit reference, so that we
         // can still detect isWithinToolboxApp vs running in mobile browser
-        window.webkitProxy = true;
+        window.webkitWasTamperedWith = true;
 
         // set up object structure if it doesn't exist yet
         window.webkit = {

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -120,7 +120,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             return;
         }
 
-        if (!realityEditor.device.environment.isDesktop()) { return; }
+        if (realityEditor.device.environment.isARMode()) { return; }
 
         if (!realityEditor.sceneGraph.getSceneNodeById('CAMERA')) { // reload after camera has been created
             setTimeout(function() {
@@ -303,7 +303,7 @@ createNameSpace('realityEditor.device.desktopCamera');
             saveCameraData(0);
             realityEditor.gui.getMenuBar().getItemByName('Load Camera Position').enable();
         });
-        const loadCameraPositionMenuItem = new realityEditor.gui.MenuItem('Load Camera Position', { shortcutKey: '_1', modifiers: ['SHIFT'], toggle: false, disabled: loadCameraData(0) === undefined }, () => {
+        const loadCameraPositionMenuItem = new realityEditor.gui.MenuItem('Load Camera Position', { shortcutKey: '_1', modifiers: ['SHIFT'], toggle: false, disabled: !loadCameraData(0) }, () => {
             loadCameraData(0);
         });
         realityEditor.gui.getMenuBar().addItemToMenu(realityEditor.gui.MENU.Camera, saveCameraPositionMenuItem);

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -64,7 +64,7 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
             return;
         }
 
-        if (!realityEditor.device.environment.isDesktop()) { return; }
+        if (realityEditor.device.environment.isARMode()) { return; }
 
         const renderingFlagName = 'loadingWorldMesh';
         realityEditor.device.environment.addSuppressedObjectRenderingFlag(renderingFlagName); // hide tools until the model is loaded

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -158,6 +158,11 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
                     gltf.traverse(obj => {
                         if (obj.type === 'Mesh' && obj.material) {
                             obj.oldMaterial = greyMaterial;
+
+                            // to improve performance on mobile devices, switch to simpler material (has very large effect)
+                            if (!realityEditor.device.environment.isDesktop() && typeof obj.originalMaterial !== 'undefined') {
+                                obj.material = obj.originalMaterial;
+                            }
                         }
                     });
 
@@ -228,13 +233,18 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
                         });
 
                         if (!PROXY) {
-                            videoPlayback = new realityEditor.videoPlayback.VideoPlaybackCoordinator();
-                            videoPlayback.setPointCloudCallback(cameraVisCoordinator.loadPointCloud.bind(cameraVisCoordinator));
-                            videoPlayback.setHidePointCloudCallback(cameraVisCoordinator.hidePointCloud.bind(cameraVisCoordinator));
-                            videoPlayback.load();
-                            window.videoPlayback = videoPlayback;
+                            const createVideoPlayback = () => {
+                                videoPlayback = new realityEditor.videoPlayback.VideoPlaybackCoordinator();
+                                videoPlayback.setPointCloudCallback(cameraVisCoordinator.loadPointCloud.bind(cameraVisCoordinator));
+                                videoPlayback.setHidePointCloudCallback(cameraVisCoordinator.hidePointCloud.bind(cameraVisCoordinator));
+                                videoPlayback.load();
+                                // window.videoPlayback = videoPlayback;
+                            }
 
                             realityEditor.gui.getMenuBar().addCallbackToItem(realityEditor.gui.ITEM.VideoPlayback, (toggled) => {
+                                if (!videoPlayback) {
+                                    createVideoPlayback(); // only create it if the user decides to use it
+                                }
                                 videoPlayback.toggleVisibility(toggled);
                             });
                         }

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -161,6 +161,7 @@ import { UNIFORMS, MAX_VIEW_FRUSTUMS } from '../../src/gui/ViewFrustum.js';
 
                             // to improve performance on mobile devices, switch to simpler material (has very large effect)
                             if (!realityEditor.device.environment.isDesktop() && typeof obj.originalMaterial !== 'undefined') {
+                                obj.material.dispose(); // free resources from the advanced material
                                 obj.material = obj.originalMaterial;
                             }
                         }

--- a/content_scripts/desktopStats.js
+++ b/content_scripts/desktopStats.js
@@ -65,7 +65,9 @@ createNameSpace('realityEditor.device.desktopStats');
             return;
         }
 
-        stats.update();
+        if (isVisible) {
+            stats.update();
+        }
         requestAnimationFrame(update);
 
         if (imageStartTime !== null) {

--- a/content_scripts/desktopStats.js
+++ b/content_scripts/desktopStats.js
@@ -32,7 +32,7 @@ createNameSpace('realityEditor.device.desktopStats');
             return;
         }
 
-        if (!realityEditor.device.environment.isDesktop()) { return; }
+        if (realityEditor.device.environment.isARMode()) { return; }
 
         // wait until the menubar is initialized
         if (typeof realityEditor.gui.setupMenuBar !== 'function') {

--- a/content_scripts/multiclientUI.js
+++ b/content_scripts/multiclientUI.js
@@ -63,7 +63,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             return;
         }
 
-        if (!realityEditor.device.environment.isDesktop()) { return; }
+        if (realityEditor.device.environment.isARMode()) { return; }
 
         realityEditor.network.addObjectDiscoveredCallback(function(object, objectKey) {
             setTimeout(function() {

--- a/content_scripts/setupMenuBar.js
+++ b/content_scripts/setupMenuBar.js
@@ -38,7 +38,8 @@ createNameSpace('realityEditor.gui');
         ToggleAnalyticsSettings: 'Toggle Analytics Settings',
         ToggleHumanPoses: 'Human Poses',
         DarkMode: 'Dark Mode',
-        CutoutViewFrustums: 'Cut Out 3D Videos'
+        CutoutViewFrustums: 'Cut Out 3D Videos',
+        ShowFPS: 'Show FPS'
     });
     exports.ITEM = ITEM;
 
@@ -134,6 +135,15 @@ createNameSpace('realityEditor.gui');
             realityEditor.avatar.toggleDebugMode(checked);
         });
         menuBar.addItemToMenu(MENU.Develop, debugAvatars);
+
+        const showFPS = new MenuItem(ITEM.ShowFPS, { toggle: true }, (checked) => {
+            if (checked) {
+                realityEditor.device.desktopStats.show();
+            } else {
+                realityEditor.device.desktopStats.hide();
+            }
+        });
+        menuBar.addItemToMenu(MENU.Develop, showFPS);
 
         const deleteAllTools = new MenuItem(ITEM.DeleteAllTools, { toggle: true }, (_checked) => {
             // console.info(objects);

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -3,10 +3,13 @@ body {
     width: 100vw;
     height: 100vh;
     overflow: hidden;
+    /*margin: 0;*/
+    /*padding: 0;*/
 }
 
 body > * {
     pointer-events: auto;
+    overflow: hidden;
 }
 
 #UIButtons > * {
@@ -59,7 +62,12 @@ body > * {
     color: lightgray;
     transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 3000, 1);
     z-index: 3000;
+    /*overflow: auto;*/
 }
+
+/*.desktopMenuBar > * {*/
+/*    overflow: auto;*/
+/*}*/
 
 .desktopMenuBarMenu {
     position: absolute;

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -74,12 +74,7 @@ body > * {
     color: lightgray;
     transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 3000, 1);
     z-index: 3000;
-    /*overflow: auto;*/
 }
-
-/*.desktopMenuBar > * {*/
-/*    overflow: auto;*/
-/*}*/
 
 .desktopMenuBarMenu {
     position: absolute;

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -3,12 +3,24 @@ body {
     width: 100vw;
     height: 100vh;
     overflow: hidden;
-    /*margin: 0;*/
-    /*padding: 0;*/
+    -webkit-user-select: none;
+    touch-action: none;
+    -webkit-touch-callout: none;
 }
 
 body > * {
     pointer-events: auto;
+    /* overflow:hidden is necessary to prevent unintentional native scrolling/zooming within iOS safari app */
+    /* but we should limit its scope as much as possible instead of adding it here */
+}
+
+/* necessary to prevent native scrolling/zooming within iOS safari app */
+.canvas-node-connections {
+    overflow: hidden;
+}
+
+/* necessary to prevent native scrolling/zooming within iOS safari app */
+.canvas-main-threejs {
     overflow: hidden;
 }
 


### PR DESCRIPTION
Adds tap, one-and-two finger drag, and pinch controls to navigate the camera in a mobile web browser. Tap without dragging to set the focus cube position. Drag with one finger to rotate. Two finger drag to pan, two finger pinch to zoom.

Adds a variety of countermeasures to try to prevent the native iOS gesture recognitions that swap tabs and pull-to-refresh and zoom out the page.

Also swaps the gltf to use the default material instead of the advanced animated/frustum-culled material on mobile browsers, to improve performance.