### PR TITLE
add fly mode keyboard shortcut to Camera menu

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -261,23 +261,27 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 }
             }.bind(this));
 
-            // enter fly mode
-            document.addEventListener('keydown', (e) => {
-                if (e.key === 'f' || e.key === 'F') {
-                    this.isFlying = !this.isFlying;
-                    if (this.isFlying) {
-                        document.body.requestPointerLock();
-                    } else {
-                        document.exitPointerLock();
-                    }
+            realityEditor.gui.getMenuBar().addCallbackToItem(realityEditor.gui.ITEM.ToggleFlyMode, (toggled) => {
+                this.isFlying = toggled;
+                if (this.isFlying) {
+                    document.body.requestPointerLock();
+                } else {
+                    document.exitPointerLock();
                 }
             });
 
             document.addEventListener('pointerlockchange', () => {
                 if (document.pointerLockElement === document.body) {
-                    this.isFlying = true;
+                    if (!this.isFlying) {
+                        realityEditor.gui.getMenuBar().getItemByName(realityEditor.gui.ITEM.ToggleFlyMode).switchToggle();
+                        this.isFlying = true;
+                    }
                 } else if (document.pointerLockElement === null) {
-                    this.isFlying = false;
+                    if (this.isFlying) {
+                        // make sure the menu item toggle state updates in response to escape key, etc
+                        realityEditor.gui.getMenuBar().getItemByName(realityEditor.gui.ITEM.ToggleFlyMode).switchToggle();
+                        this.isFlying = false;
+                    }
                 }
                 this.switchMode();
             });

--- a/content_scripts/setupMenuBar.js
+++ b/content_scripts/setupMenuBar.js
@@ -37,7 +37,8 @@ createNameSpace('realityEditor.gui');
         ToggleHumanPoses: 'Human Poses',
         DarkMode: 'Dark Mode',
         CutoutViewFrustums: 'Cut Out 3D Videos',
-        ShowFPS: 'Show FPS'
+        ShowFPS: 'Show FPS',
+        ToggleFlyMode: 'Fly Mode'
     });
     exports.ITEM = ITEM;
 
@@ -96,6 +97,9 @@ createNameSpace('realityEditor.gui');
 
         const toggleDarkMode = new MenuItem(ITEM.DarkMode, { toggle: true, defaultVal: true }, null);
         menuBar.addItemToMenu(MENU.View, toggleDarkMode);
+
+        const toggleFlyMode = new MenuItem(ITEM.ToggleFlyMode, { toggle: true, shortcutKey: 'F', defaultVal: false }, null);
+        menuBar.addItemToMenu(MENU.Camera, toggleFlyMode);
 
         const rzvAdvanceCameraShader = new MenuItem(ITEM.AdvanceCameraShader, { disabled: true }, null);
         menuBar.addItemToMenu(MENU.Camera, rzvAdvanceCameraShader);


### PR DESCRIPTION
Previously the F keyboard shortcut was handled separately from other keyboard shortcuts, and didn't appear in the menu bar. Now it shows in the menu to help remind the user of which key to press to activate it.