### PR TITLE
pressing R key while dragging a tool rotates the tool towards your camera view on remote operator

### DIFF
--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -178,6 +178,16 @@ createNameSpace('realityEditor.device.desktopAdapter');
                         startY: touchPosition.y
                     };
                 }
+            } else if (code === keyboard.keyCodes.R) {
+                // rotate tool towards camera a single time when you press the R key while dragging a tool
+                let tool = realityEditor.device.getEditingVehicle();
+                if (!tool) return;
+                let toolSceneNode = realityEditor.sceneGraph.getSceneNodeById(tool.uuid);
+                if (!toolSceneNode) return;
+                // we don't include scale in new matrix otherwise it can shrink/grow
+                let modelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(tool.uuid, 'CAMERA', {flipX: true, flipY: true, includeScale: false});
+                let rootNode = realityEditor.sceneGraph.getSceneNodeById('ROOT');
+                toolSceneNode.setPositionRelativeTo(rootNode, modelMatrix);
             }
         });
         keyboard.onKeyUp(function(code) {


### PR DESCRIPTION
Works on 2D tools that don't set `spatialInterface.alwaysFaceCamera(true)` (all of them do, but here's a demo of how it looks if I turned off that setting on the video tool)
![rotate-tool-towards-camera-remote-operator-v1 2023-08-29 15_55_05](https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/assets/32580292/04540a9b-5ccb-4822-86be-ccdb337a2ab5)

More importantly for our current demos, allows the remote operator to rotate the 3D onshape models by pressing the R key while dragging them:
![rotate-tool-towards-camera-remote-operator-v1 2023-08-29 15_57_25](https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/assets/32580292/11aadc6d-2e39-4efb-8442-86475bbc81f0)

Somewhat similar to how the remote operator can press the S key while dragging to scale tools. This could probably use a more thoughtful UI overhaul at some point – this is more of a shortcut I'm taking for now to add the functionality.
