### PR TITLE
small performance optimizations

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -768,6 +768,8 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             if (!options.skipApplying) {
                 if (this.cameraNode.id === 'CAMERA') {
                     realityEditor.sceneGraph.setCameraPosition(newCameraMatrix);
+                    let cameraNode = realityEditor.sceneGraph.getCameraNode();
+                    cameraNode.needsRerender = true;
                 } else {
                     this.cameraNode.setLocalMatrix(newCameraMatrix);
                 }

--- a/content_scripts/desktopRenderer.js
+++ b/content_scripts/desktopRenderer.js
@@ -173,7 +173,9 @@ import {ShaderMode} from './Shaders.js';
                             obj.oldMaterial = greyMaterial;
 
                             // to improve performance on mobile devices, switch to simpler material (has very large effect)
-                            if (!realityEditor.device.environment.isDesktop() && typeof obj.originalMaterial !== 'undefined') {
+                            // TODO: to re-enable frustum culling on desktop, add this: && !realityEditor.device.environment.isDesktop()
+                            //  so that we don't swap to the original material on desktop. also need to update threejsScene.js
+                            if (typeof obj.originalMaterial !== 'undefined') {
                                 obj.material.dispose(); // free resources from the advanced material
                                 obj.material = obj.originalMaterial;
 


### PR DESCRIPTION
Swaps the area target mesh material to the simpler one on all devices, since we aren't currently using the frustum cutout shader. This improves performance. Also updates the sceneGraph more immediately after the camera updates.