### PR TITLE
remove rotateFactor from strafe, so you can move at full speed while looking down

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -746,9 +746,8 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
                 let camLookAt = new THREE.Vector3().fromArray(this.getCameraDirection());
                 let angle = camLookAt.clone().angleTo(new THREE.Vector3(camLookAt.x, 0, camLookAt.z));
                 // rotateFactor is a quadratic function that goes through (+-PI/2, 0) and (0, 1), so that when camera gets closer to 2 poles, the slower it rotates
-                let rotateFactor = -Math.pow(angle / Math.PI, 2) * 4 + 1;
-                this.position = add(this.position, scalarMultiply(this.velocity, rotateFactor));
-                this.targetPosition = add(this.targetPosition, scalarMultiply(this.targetVelocity, rotateFactor));
+                this.position = add(this.position, this.velocity);
+                this.targetPosition = add(this.targetPosition, this.targetVelocity);
             }
 
             // tween the matrix every frame to animate it to the new position


### PR DESCRIPTION
Keeps rotateFactor in the rotation calculations to slow down rotations while looking down, but removes it from the panning calculations so that you can pan at full speed regardless of what angle you're viewing from. I don't think it's needed here, but let me know if you remember it being necessary.

Before:
![Remove-Rotation-Factor-From-Strafe-before](https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/assets/32580292/5cc15086-b654-45b5-ab4e-94caefb011da)

After:
![Remove-Rotation-Factor-From-Strafe-after](https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/assets/32580292/86c7c119-59fe-4f79-9205-1023641ba4e7)
