### PR TITLE
Ignore G key (camera focus shortcut) while tool or other input is capturing keyboard events

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -266,6 +266,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 
             // focus camera on the focus point
             document.addEventListener('keypress', function (e) {
+                if (realityEditor.device.keyboardEvents.isKeyboardActive()) { return; } // ignore if a tool is using the keyboard
                 if (e.key === 'g' || e.key === 'G') {
                     this.focus(this.focusTargetCube.position.clone());
                 }


### PR DESCRIPTION
Other keyboard shortcuts have this guard, but the camera focus shortcut was missing it. (I noticed the issue when typing a G into the edit username textfield)