### PR TITLE
KeyboardListener.js listens for blur events to reset key states

### DIFF
--- a/content_scripts/KeyboardListener.js
+++ b/content_scripts/KeyboardListener.js
@@ -5,7 +5,6 @@
 createNameSpace('realityEditor.device');
 
 (function(exports) {
-
     class KeyboardListener {
         constructor() {
             /**
@@ -118,6 +117,15 @@ createNameSpace('realityEditor.device');
                     });
                 }
             }.bind(this));
+
+            // reset all keys to 'up' if the window loses focus, to prevent cases where a key gets "stuck" down
+            window.addEventListener('blur', () => {
+                for (let code in this.keyStates) {
+                    if (this.keyStates.hasOwnProperty(code)) {
+                        this.keyStates[code] = 'up';
+                    }
+                }
+            });
         }
         onKeyDown(callback) {
             this.callbacks.onKeyDown.push(callback);


### PR DESCRIPTION
I was debugging why sometimes the keyboard shortcuts stop working. Looks like it was because if any of the modifier keys gets "stuck" down then the menu item key shortcuts don't match the KeyboardListener's state anymore so the callbacks don't trigger. Listening to blur events on the window seems to fix this in case a key was pressed down but the window lost focus before the key is released.