### PR TITLE
AI function calling, state summary, and spatial references

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -700,8 +700,8 @@ import Splatting from '../../src/splatting/Splatting.js';
         }
         // if specify a focus direction, the camera will look into that direction. Note that dir is expected to be a unit vector
         // if not, move the camera while keeping its lookAt direction
-        focus(pos, dir) {
-            let zoomFactor = 3000;
+        focus(pos, dir, zoomDistanceMm = 3000) {
+            let zoomFactor = zoomDistanceMm;
             this.targetPosition[0] = pos.x;
             this.targetPosition[1] = pos.y;
             this.targetPosition[2] = pos.z;

--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -262,7 +262,7 @@ import Splatting from '../../src/splatting/Splatting.js';
                 scrollTimeout = setTimeout(function () {
                     this.triggerScaleCallbacks(false);
                     this.preRotateDistanceToTarget = null;
-                    Splatting.toggleGSRaycast(true);
+                    Splatting.toggleGSRaycast(false);
 
                 }.bind(this), 150);
 

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -391,7 +391,7 @@ import { TouchControlButtons } from './TouchControlButtons.js';
         });
 
         realityEditor.ai.registerCallback('shouldFocusVirtualCamera', function (params) {
-            focusVirtualCamera(new Vector3(params.pos.x, params.pos.y, params.pos.z), new Vector3(params.dir.x, params.dir.y, params.dir.z));
+            focusVirtualCamera(new Vector3(params.pos.x, params.pos.y, params.pos.z), new Vector3(params.dir.x, params.dir.y, params.dir.z), params.zoomDistanceMm);
         });
     }
 
@@ -771,9 +771,9 @@ import { TouchControlButtons } from './TouchControlButtons.js';
         });
     }
 
-    function focusVirtualCamera(pos, dir) {
+    function focusVirtualCamera(pos, dir, zoomDistanceMm = 3000) {
         if (!virtualCamera || !virtualCameraEnabled) return;
-        virtualCamera.focus(pos, dir);
+        virtualCamera.focus(pos, dir, zoomDistanceMm);
     }
 
     exports.update = update;

--- a/content_scripts/setupMenuBar.js
+++ b/content_scripts/setupMenuBar.js
@@ -190,7 +190,7 @@ import Splatting from '../../src/splatting/Splatting.js';
         });
         menuBar.addItemToMenu(MENU.Help, showDeveloper);
 
-        const showAIChat = new MenuItem(ITEM.ShowAIChatbot, { toggle: true }, (checked) => {
+        const showAIChat = new MenuItem(ITEM.ShowAIChatbot, { toggle: true, shortcutKey: 'BACK_SLASH' }, (checked) => {
             if (checked) {
                 realityEditor.ai.showDialogue();
             } else {


### PR DESCRIPTION
Adds a backslash keyboard shortcut to pull up the AI chat GUI, and adjusts the zoom distance when clicking on spatial hyperlinks in the AI chat.

Part of the https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/725 set of PRs.