### PR TITLE
Camera perspective memory bar – UI for saving/loading camera positions

### DIFF
--- a/content_resources/memory-add.svg
+++ b/content_resources/memory-add.svg
@@ -1,0 +1,3 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 84"><defs><style>.cls-1{fill
+    :none;stroke:#fff;stroke-width:4;stroke-miterlimit:10;}</style></defs><line class="cls-1" x1="42" y1="64"
+                                                                                x2="42" y2="20"/><line class="cls-1" x1="20" y1="42" x2="64" y2="42"/></svg>

--- a/content_scripts/CameraPositionMemoryBar.js
+++ b/content_scripts/CameraPositionMemoryBar.js
@@ -39,7 +39,7 @@ export class CameraPositionMemoryBar {
         barParent.classList.add('camera-position-memory-bar-parent');
 
         let bar = document.createElement('div');
-        bar.classList.add('camera-position-memory-bar')
+        bar.classList.add('camera-position-memory-bar');
         this.memorySlots.forEach(slot => {
             bar.appendChild(slot.dom);
         });
@@ -124,7 +124,7 @@ export class CameraPositionMemoryBar {
      */
     saveMemoryInSlot(index) {
         if (index >= this.memorySlots.length) {
-            console.warn(`memory slot ${index} doesn't exist; only goes up to ${this.memorySlots.length-1}`)
+            console.warn(`memory slot ${index} doesn't exist; only goes up to ${this.memorySlots.length - 1}`);
             return;
         }
         let memorySlot = this.memorySlots[index];
@@ -141,7 +141,7 @@ export class CameraPositionMemoryBar {
      */
     loadMemoryFromSlot(index) {
         if (index >= this.memorySlots.length) {
-            console.warn(`memory slot ${index} doesn't exist; only goes up to ${this.memorySlots.length-1}`)
+            console.warn(`memory slot ${index} doesn't exist; only goes up to ${this.memorySlots.length - 1}`);
             return;
         }
         let memorySlot = this.memorySlots[index];
@@ -210,7 +210,7 @@ class CameraPositionMemorySlot {
      * @return {Promise<{position: number[], direction: number[], screenshotImageSrc: string}>}
      */
     captureMemoryForCurrentState() {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             let { position, direction } = this.memoryBar.cameraPositionGetter();
 
             let captureFunction = realityEditor.spatialCursor.isGSActive() ?

--- a/content_scripts/CameraPositionMemoryBar.js
+++ b/content_scripts/CameraPositionMemoryBar.js
@@ -5,8 +5,21 @@ const IMAGE_SRC = {
     // load: 'addons/vuforia-spatial-remote-operator-addon/memory-load.svg',
 };
 
+// each thumbnail is only a few kb, but we can prevent filling up localStorage with hundreds of metaverses
+// of old thumbnails by imposing a limit, and the thumbnails used least recently will be cleared out
+const MAX_LOCAL_STORAGE_ENTRIES = 100;
+const ID_PATTERN = /^camera-position-memory-slot-\d+-.*$/;
+
+/**
+ * A UI component that allows you to save and load `CameraPositionMemory`s into one of 5 slots
+ * Saving a memory stores your camera perspective and a thumbnail of your current view
+ * Clicking a saved memory restores your camera position/direction to that view
+ * These are saved per-client and per-worldObject, in localStorage (for now – could be shared/sync'd
+ * on server for all clients if desired in future).
+ */
 export class CameraPositionMemoryBar {
-    constructor(cameraPositionGetter) {
+    constructor(worldId, cameraPositionGetter) {
+        this.worldId = worldId; // used to save/load memories per-world
         this.cameraPositionGetter = cameraPositionGetter;
         this.callbacks = {
             onMemoryLoaded: []
@@ -54,7 +67,15 @@ export class CameraPositionMemoryBar {
     buildMemorySlots(numMemories) {
         let memories = [];
         for (let i = 0; i < numMemories; i++) {
-            let slot = new CameraPositionMemorySlot(this);
+            let slot = new CameraPositionMemorySlot(this, i);
+
+            // load from localStorage if available
+            let savedMemoryString = window.localStorage.getItem(slot.getId());
+            if (typeof savedMemoryString === 'string') {
+                let memory = JSON.parse(savedMemoryString);
+                slot.saveMemory(memory.position, memory.direction, memory.thumbnailSrc, memory.lastUsedDate, memory.createdDate);
+            }
+
             memories.push(slot);
         }
         return memories;
@@ -78,13 +99,16 @@ export class CameraPositionMemoryBar {
 class CameraPositionMemorySlot {
     /**
      * @param {CameraPositionMemoryBar} parentBar
+     * @param {number} index
      */
-    constructor(parentBar) {
+    constructor(parentBar, index) {
         this.parentBar = parentBar;
+        this.index = index;
         this.dom = this.buildDom();
         this.memory = null;
     }
     /**
+     * Sets up the dom elements for this memory slot, and adds the click event listeners
      * @return {HTMLDivElement}
      */
     buildDom() {
@@ -92,8 +116,6 @@ class CameraPositionMemorySlot {
         slot.classList.add('camera-position-memory-slot');
 
         let image = document.createElement('div');
-        // image.width = '120px';
-        // image.height = '80px';
         image.classList.add('camera-position-memory-slot-image');
         // image.src = IMAGE_SRC.save;
         image.style.backgroundImage = `url('${IMAGE_SRC.save}')`;
@@ -101,7 +123,9 @@ class CameraPositionMemorySlot {
         slot.appendChild(image);
 
         let xButton = document.createElement('div');
-        xButton.classList.add('camera-position-memory-slot-x');
+        xButton.classList.add('camera-position-memory-slot-x', 'hidden-memory-bar');
+        xButton.textContent = 'X';
+        slot.appendChild(xButton);
 
         slot.addEventListener('click', () => {
             if (this.memory) {
@@ -109,40 +133,155 @@ class CameraPositionMemorySlot {
             } else {
                 let { position, direction } = this.parentBar.cameraPositionGetter();
 
-                Splatting.captureScreenshot();
+                Splatting.captureScreenshot({ outputWidth: 120, useJpgCompression: true, jpgQuality: 0.7 });
                 setTimeout(() => {
                     let screenshotImage = Splatting.getMostRecentScreenshot();
-                    this.saveMemory(position, direction, screenshotImage);
+                    this.saveMemory(position, direction, screenshotImage, undefined, undefined);
                 }, 100);
             }
         });
 
+        // Add click event listener to the X button
+        xButton.addEventListener('click', (event) => {
+            event.stopPropagation(); // Prevent triggering any parent click events
+            console.log('X button clicked');
+            // remove the memory from the slot
+            this.clearMemory();
+        });
+
         return slot;
     }
-    saveMemory(position, direction, thumbnailSrc) {
-        this.memory = new CameraPositionMemory(position, direction);
+    /**
+     * Saves the specified arguments (position/direction/thumbnail) into this slot, and saves to localStorage
+     * @param {number[]} position – [X,Y,Z] of camera position
+     * @param {number[]} direction - [X,Y,Z] of camera direction
+     * @param {string} thumbnailSrc - base64-encoded image screenshot of view
+     * @param {string} lastUsedDate - ISO date-string of when memory was last saved or restored
+     * @param {string} createdDate - ISO date-string of when memory was originally created
+     */
+    saveMemory(position, direction, thumbnailSrc, lastUsedDate, createdDate) {
+        let now = new Date().toISOString(); // Date.now(); // last used date is now. also the created date if no created date provided to function.
+        this.memory = new CameraPositionMemory(position, direction, thumbnailSrc, lastUsedDate || now, createdDate || now);
         // set image to thumbnail
         let image = this.dom.querySelector('.camera-position-memory-slot-image');
-        // image.src = thumbnailSrc;
         image.style.backgroundImage = `url('${thumbnailSrc}')`;
         image.style.backgroundSize = 'cover';
+        let xButton = this.dom.querySelector('.camera-position-memory-slot-x');
+        if (xButton) {
+            xButton.classList.remove('hidden-memory-bar'); // show the delete button
+        }
+
+        // save to localStorage, and delete old thumbnails from other worlds from localStorage if there are too many
+        try {
+            window.localStorage.setItem(this.getId(), this.memory.toString());
+            this.manageStoredThumbnails(MAX_LOCAL_STORAGE_ENTRIES);
+        } catch (e) {
+            if (e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+                console.error('Local storage quota exceeded. Clearing old entries.');
+                this.manageStoredThumbnails(MAX_LOCAL_STORAGE_ENTRIES / 2); // use stricter limit if error
+            } else {
+                console.error('Error storing thumbnail:', e);
+            }
+        }
     }
+    /**
+     * Removes the memory from this slot, so a new one can be added
+     */
     clearMemory() {
         this.memory = null;
         // reset image to "+"
         let image = this.dom.querySelector('.camera-position-memory-slot-image');
         // image.src = IMAGE_SRC.save;
-        image.backgroundImage = `url('${IMAGE_SRC.save}')`;
+        image.style.backgroundImage = `url('${IMAGE_SRC.save}')`;
         image.style.backgroundSize = '50%';
+        window.localStorage.removeItem(this.getId());
+
+        let xButton = this.dom.querySelector('.camera-position-memory-slot-x');
+        if (xButton) {
+            xButton.classList.add('hidden-memory-bar');
+        }
     }
+    /**
+     * Tell the parent to restore the camera position/direction of this memory into the view
+     */
     loadMemory() {
+        this.memory.lastUsedDate = new Date().toISOString(); // update last-used date whenever it's used
+        window.localStorage.setItem(this.getId(), this.memory.toString());
         this.parentBar.memorySelected(this.memory);
+    }
+
+    /**
+     * Helper function to get a unique ID for this memory slot in this world
+     * @return {string}
+     */
+    getId() {
+        if (!this.parentBar.worldId) {
+            console.warn('trying to save/load CameraPositionMemory for null world id; something may be wrong');
+        }
+        let worldId = this.parentBar.worldId || 'null-world-id';
+        return `camera-position-memory-slot-${this.index}-${worldId}`;
+    }
+
+    /**
+     * Delete the oldest thumbnails from localStorage if more than `limit` thumbnails are saved
+     * @param {number} limit
+     */
+    manageStoredThumbnails(limit) {
+        // get all of the localStorage memory keys not part of this world
+        let allKeys = this.getAllKeysMatchingPattern(ID_PATTERN);
+        let keysFromOtherWorlds = allKeys.filter(key => {
+            return !key.includes(this.parentBar.worldId);
+        });
+        let numKeysInThisWorld = allKeys.length - keysFromOtherWorlds.length;
+        // get and sort them by lastUsedDate, and remove the oldest ones if needed
+        let keyAges = this.getKeyAges(keysFromOtherWorlds);
+        let limitForOtherWorlds = limit - numKeysInThisWorld;
+        this.removeOldestKeys(keyAges, limitForOtherWorlds);
+    }
+    getAllKeysMatchingPattern(thisRegex) {
+        let keys = [];
+        for (let i = 0; i < window.localStorage.length; i++) {
+            let key = window.localStorage.key(i);
+            if (thisRegex.test(key)) {
+                keys.push(key);
+            }
+        }
+        return keys;
+    }
+    getKeyAges(keys) {
+        return keys.map(key => {
+            let item = JSON.parse(window.localStorage.getItem(key));
+            return {
+                key,
+                lastUsedDate: item ? new Date(item.lastUsedDate) : new Date(0)
+            };
+        });
+    }
+    removeOldestKeys(keys, limit) {
+        keys.sort((a, b) => a.lastUsedDate - b.lastUsedDate);
+        while (keys.length > limit) {
+            let oldest = keys.shift();
+            console.log(`removing ${oldest.key} memory thumbnail from localStorage because too many keys (${keys.length} out of ${limit})`);
+            window.localStorage.removeItem(oldest.key);
+        }
     }
 }
 
 class CameraPositionMemory {
-    constructor(position, direction) {
+    constructor(position, direction, thumbnailSrc, lastUsedDate, createdDate) {
         this.position = position;
         this.direction = direction;
+        this.thumbnailSrc = thumbnailSrc;
+        this.lastUsedDate = lastUsedDate;
+        this.createdDate = createdDate;
+    }
+    toString() {
+        return JSON.stringify({
+            position: this.position,
+            direction: this.direction,
+            thumbnailSrc: this.thumbnailSrc,
+            createdDate: this.createdDate,
+            lastUsedDate: this.lastUsedDate,
+        });
     }
 }

--- a/content_scripts/CameraPositionMemoryBar.js
+++ b/content_scripts/CameraPositionMemoryBar.js
@@ -1,0 +1,148 @@
+import Splatting from '../../src/splatting/Splatting.js';
+
+const IMAGE_SRC = {
+    save: 'addons/vuforia-spatial-remote-operator-addon/memory-add.svg',
+    // load: 'addons/vuforia-spatial-remote-operator-addon/memory-load.svg',
+};
+
+export class CameraPositionMemoryBar {
+    constructor(cameraPositionGetter) {
+        this.cameraPositionGetter = cameraPositionGetter;
+        this.callbacks = {
+            onMemoryLoaded: []
+        };
+
+        const NUM_MEMORIES = 5;
+        this.memorySlots = this.buildMemorySlots(NUM_MEMORIES);
+        this.dom = this.buildDom();
+        document.body.appendChild(this.dom);
+
+        this.dom.classList.add('hidden-memory-bar');
+
+        let keyboard = new realityEditor.device.KeyboardListener();
+        keyboard.onKeyDown((code) => {
+            if (realityEditor.device.keyboardEvents.isKeyboardActive()) { return; } // ignore if a tool is using the keyboard
+
+            // while shift is down, turn on the laser beam
+            if (code === keyboard.keyCodes.PERIOD) {
+                if (this.dom.classList.contains('hidden-memory-bar')) {
+                    this.dom.classList.remove('hidden-memory-bar');
+                } else {
+                    this.dom.classList.add('hidden-memory-bar');
+                }
+            }
+        });
+    }
+    /**
+     * @return {HTMLDivElement}
+     */
+    buildDom() {
+        let barParent = document.createElement('div');
+        barParent.classList.add('camera-position-memory-bar-parent');
+        let bar = document.createElement('div');
+        bar.classList.add('camera-position-memory-bar')
+        this.memorySlots.forEach(slot => {
+            bar.appendChild(slot.dom);
+        });
+        barParent.appendChild(bar);
+        return barParent;
+    }
+    /**
+     * @param {number} numMemories
+     * @return {CameraPositionMemorySlot[]}
+     */
+    buildMemorySlots(numMemories) {
+        let memories = [];
+        for (let i = 0; i < numMemories; i++) {
+            let slot = new CameraPositionMemorySlot(this);
+            memories.push(slot);
+        }
+        return memories;
+    }
+    /**
+     * @param {function} cb
+     */
+    onMemorySelected(cb) {
+        this.callbacks.onMemoryLoaded.push(cb);
+    }
+    /**
+     * @param {CameraPositionMemory} memory
+     */
+    memorySelected(memory) {
+        this.callbacks.onMemoryLoaded.forEach(cb => {
+            cb(memory.position, memory.direction);
+        });
+    }
+}
+
+class CameraPositionMemorySlot {
+    /**
+     * @param {CameraPositionMemoryBar} parentBar
+     */
+    constructor(parentBar) {
+        this.parentBar = parentBar;
+        this.dom = this.buildDom();
+        this.memory = null;
+    }
+    /**
+     * @return {HTMLDivElement}
+     */
+    buildDom() {
+        let slot = document.createElement('div');
+        slot.classList.add('camera-position-memory-slot');
+
+        let image = document.createElement('div');
+        // image.width = '120px';
+        // image.height = '80px';
+        image.classList.add('camera-position-memory-slot-image');
+        // image.src = IMAGE_SRC.save;
+        image.style.backgroundImage = `url('${IMAGE_SRC.save}')`;
+        image.style.backgroundSize = '50%';
+        slot.appendChild(image);
+
+        let xButton = document.createElement('div');
+        xButton.classList.add('camera-position-memory-slot-x');
+
+        slot.addEventListener('click', () => {
+            if (this.memory) {
+                this.loadMemory();
+            } else {
+                let { position, direction } = this.parentBar.cameraPositionGetter();
+
+                Splatting.captureScreenshot();
+                setTimeout(() => {
+                    let screenshotImage = Splatting.getMostRecentScreenshot();
+                    this.saveMemory(position, direction, screenshotImage);
+                }, 100);
+            }
+        });
+
+        return slot;
+    }
+    saveMemory(position, direction, thumbnailSrc) {
+        this.memory = new CameraPositionMemory(position, direction);
+        // set image to thumbnail
+        let image = this.dom.querySelector('.camera-position-memory-slot-image');
+        // image.src = thumbnailSrc;
+        image.style.backgroundImage = `url('${thumbnailSrc}')`;
+        image.style.backgroundSize = 'cover';
+    }
+    clearMemory() {
+        this.memory = null;
+        // reset image to "+"
+        let image = this.dom.querySelector('.camera-position-memory-slot-image');
+        // image.src = IMAGE_SRC.save;
+        image.backgroundImage = `url('${IMAGE_SRC.save}')`;
+        image.style.backgroundSize = '50%';
+    }
+    loadMemory() {
+        this.parentBar.memorySelected(this.memory);
+    }
+}
+
+class CameraPositionMemory {
+    constructor(position, direction) {
+        this.position = position;
+        this.direction = direction;
+    }
+}

--- a/content_scripts/CameraPositionMemoryBar.js
+++ b/content_scripts/CameraPositionMemoryBar.js
@@ -31,20 +31,6 @@ export class CameraPositionMemoryBar {
         document.body.appendChild(this.dom);
 
         this.dom.classList.add('hidden-memory-bar');
-
-        let keyboard = new realityEditor.device.KeyboardListener();
-        keyboard.onKeyDown((code) => {
-            if (realityEditor.device.keyboardEvents.isKeyboardActive()) { return; } // ignore if a tool is using the keyboard
-
-            // while shift is down, turn on the laser beam
-            if (code === keyboard.keyCodes.PERIOD) {
-                if (this.dom.classList.contains('hidden-memory-bar')) {
-                    this.dom.classList.remove('hidden-memory-bar');
-                } else {
-                    this.dom.classList.add('hidden-memory-bar');
-                }
-            }
-        });
     }
     /**
      * @return {HTMLDivElement}
@@ -93,6 +79,13 @@ export class CameraPositionMemoryBar {
         this.callbacks.onMemoryLoaded.forEach(cb => {
             cb(memory.position, memory.direction);
         });
+    }
+    toggleVisibility(shouldShow) {
+        if (shouldShow) {
+            this.dom.classList.remove('hidden-memory-bar');
+        } else {
+            this.dom.classList.add('hidden-memory-bar');
+        }
     }
 }
 

--- a/content_scripts/CameraPositionMemoryBar.js
+++ b/content_scripts/CameraPositionMemoryBar.js
@@ -1,4 +1,4 @@
-import Splatting from '../../src/splatting/Splatting.js';
+import { captureScreenshot } from '../../src/gui/sceneCapture.js';
 
 // each thumbnail is only a few kb, but we can prevent filling up localStorage with hundreds of metaverses
 // of old thumbnails by imposing a limit, and the thumbnails used least recently will be cleared out
@@ -213,10 +213,9 @@ class CameraPositionMemorySlot {
         return new Promise((resolve, _reject) => {
             let { position, direction } = this.memoryBar.cameraPositionGetter();
 
-            let captureFunction = realityEditor.spatialCursor.isGSActive() ?
-                Splatting.captureScreenshot : realityEditor.gui.threejsScene.captureScreenshot;
+            let canvasId = realityEditor.spatialCursor.isGSActive() ? 'gsCanvas' : 'mainThreejsCanvas';
 
-            captureFunction({ outputWidth: 120, useJpgCompression: true, jpgQuality: 0.7 }).then(screenshotImageSrc => {
+            captureScreenshot(canvasId, { outputWidth: 120, useJpgCompression: true, jpgQuality: 0.7 }).then(screenshotImageSrc => {
                 resolve({position, direction, screenshotImageSrc});
             });
         });

--- a/content_scripts/CameraPositionMemoryBar.js
+++ b/content_scripts/CameraPositionMemoryBar.js
@@ -126,11 +126,12 @@ class CameraPositionMemorySlot {
             } else {
                 let { position, direction } = this.parentBar.cameraPositionGetter();
 
-                Splatting.captureScreenshot({ outputWidth: 120, useJpgCompression: true, jpgQuality: 0.7 });
-                setTimeout(() => {
-                    let screenshotImage = Splatting.getMostRecentScreenshot();
+                let captureFunction = realityEditor.spatialCursor.isGSActive() ?
+                    Splatting.captureScreenshot : realityEditor.gui.threejsScene.captureScreenshot;
+
+                captureFunction({ outputWidth: 120, useJpgCompression: true, jpgQuality: 0.7 }).then(screenshotImage => {
                     this.saveMemory(position, direction, screenshotImage, undefined, undefined);
-                }, 100);
+                });
             }
         });
 

--- a/content_scripts/MenuBar.js
+++ b/content_scripts/MenuBar.js
@@ -339,6 +339,11 @@ createNameSpace('realityEditor.gui');
                 return false;
             }
         }
+        isToggled() {
+            if (!this.options.toggle) { return false; }
+            let checkmark = this.domElement.querySelector('.desktopMenuBarItemCheckmark');
+            return !checkmark.classList.contains('desktopMenuBarItemCheckmarkHidden');
+        }
         disable() {
             this.domElement.classList.add('desktopMenuBarItemDisabled');
             let checkmark = this.domElement.querySelector('.desktopMenuBarItemCheckmark');

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -308,9 +308,17 @@ import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
                 } catch (e) {
                     console.warn('Error loading camera position', e);
                 }
+                memoryBar.toggleVisibility(false);
+                toggleMemoryBarMenuItem.switchToggle();
             });
+
+            const toggleMemoryBarMenuItem = new realityEditor.gui.MenuItem('Toggle Memory Bar', { shortcutKey: 'PERIOD', toggle: true, disabled: false }, (checked) => {
+                memoryBar.toggleVisibility(checked);
+            });
+            realityEditor.gui.getMenuBar().addItemToMenu(realityEditor.gui.MENU.Camera, toggleMemoryBarMenuItem);
         });
 
+        // TODO: should this be combined with the memoryBar now?
         // Only one gets a menu item to avoid crowding, but they all get a shortcut key
         const saveCameraPositionMenuItem = new realityEditor.gui.MenuItem('Save Camera Position', { shortcutKey: '_1', modifiers: ['ALT'], toggle: false, disabled: false }, () => {
             saveCameraData(0);

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -12,6 +12,7 @@ import { Vector3 } from '../../thirdPartyCode/three/three.module.js';
 import { CameraFollowCoordinator } from './CameraFollowCoordinator.js';
 import { MotionStudyFollowable } from './MotionStudyFollowable.js';
 import { TouchControlButtons } from './TouchControlButtons.js';
+import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
 
 /**
  * @fileOverview realityEditor.device.desktopCamera.js
@@ -281,6 +282,27 @@ import { TouchControlButtons } from './TouchControlButtons.js';
                 console.warn('Error parsing saved camera position data', e);
             }
         };
+
+        const getCameraPositionDirection = () => {
+            const cameraPosition = [...virtualCamera.position];
+            const cameraDirection = virtualCamera.getCameraDirection();
+            return {
+                position: cameraPosition,
+                direction: cameraDirection,
+            };
+        };
+
+        let memoryBar = new CameraPositionMemoryBar(getCameraPositionDirection);
+
+        memoryBar.onMemorySelected((position, direction) => {
+            if (virtualCamera.lockOnMode) return;
+            try {
+                virtualCamera.position = [...position];
+                virtualCamera.setCameraDirection(direction);
+            } catch (e) {
+                console.warn('Error loading camera position', e);
+            }
+        });
 
         // Only one gets a menu item to avoid crowding, but they all get a shortcut key
         const saveCameraPositionMenuItem = new realityEditor.gui.MenuItem('Save Camera Position', { shortcutKey: '_1', modifiers: ['ALT'], toggle: false, disabled: false }, () => {

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -292,16 +292,23 @@ import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
             };
         };
 
-        let memoryBar = new CameraPositionMemoryBar(getCameraPositionDirection);
+        let memoryBar = null;
+        // to save and load memories per world object, this need to happen after localization
+        realityEditor.worldObjects.onLocalizedWithinWorld((objectKey) => {
+            if (objectKey === realityEditor.worldObjects.getLocalWorldId()) return; // skip local world
+            if (memoryBar) return; // only do this once
 
-        memoryBar.onMemorySelected((position, direction) => {
-            if (virtualCamera.lockOnMode) return;
-            try {
-                virtualCamera.position = [...position];
-                virtualCamera.setCameraDirection(direction);
-            } catch (e) {
-                console.warn('Error loading camera position', e);
-            }
+            memoryBar = new CameraPositionMemoryBar(objectKey, getCameraPositionDirection);
+
+            memoryBar.onMemorySelected((position, direction) => {
+                if (virtualCamera.lockOnMode) return;
+                try {
+                    virtualCamera.position = [...position];
+                    virtualCamera.setCameraDirection(direction);
+                } catch (e) {
+                    console.warn('Error loading camera position', e);
+                }
+            });
         });
 
         // Only one gets a menu item to avoid crowding, but they all get a shortcut key

--- a/content_scripts/setupMenuBar.js
+++ b/content_scripts/setupMenuBar.js
@@ -209,19 +209,19 @@ import Splatting from '../../src/splatting/Splatting.js';
             }
         });
         menuBar.addItemToMenu(MENU.Help, showAIChat);
-        
+
         const gsSettingsPanel = new MenuItem(ITEM.GSSettingsPanel, { toggle: true, defaultVal: false }, (checked) => {
             if (checked) {
-                Splatting.showGSSettingsPanel()
+                Splatting.showGSSettingsPanel();
             } else {
                 Splatting.hideGSSettingsPanel();
             }
-        })
+        });
         menuBar.addItemToMenu(MENU.Develop, gsSettingsPanel);
-        
+
         const gsCanToggleRaycast = new MenuItem(ITEM.GSToggleRaycast, { shortcutKey: 'FORWARD_SLASH', toggle: true, defaultVal: true }, (checked) => {
             realityEditor.spatialCursor.gsCanToggleRaycast(checked);
-        })
+        });
         menuBar.addItemToMenu(MENU.Develop, gsCanToggleRaycast);
 
         document.body.appendChild(menuBar.domElement);

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -290,3 +290,46 @@ body > * {
     height: 100%;
     cursor: pointer;
 }
+
+.camera-position-memory-bar-parent {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    left: 0;
+    top: 150px;
+}
+
+.camera-position-memory-bar {
+    background-color: rgba(0,0,0,0.25);
+    border-radius: 10px;
+    padding: 5px;
+}
+
+.camera-position-memory-slot {
+    width: 100px;
+    height: 80px;
+    border: 2px solid white;
+    background-color: rgba(0,0,0,0.5);
+    border-radius: 10px;
+    display: inline-block;
+    margin: 10px;
+    cursor: pointer;
+    overflow: hidden;
+    &:hover {
+        background-color: rgba(155,155,155,0.5);
+    }
+}
+
+.camera-position-memory-slot-image {
+    width: 100%;
+    height: 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    /* In JS, you can override this from cover to 50% depending on which image is shown */
+    background-size: cover; /* Make sure it fills the container with no stretching */
+}
+
+.hidden-memory-bar {
+    display: none;
+}

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -330,6 +330,28 @@ body > * {
     background-size: cover; /* Make sure it fills the container with no stretching */
 }
 
+.camera-position-memory-slot-x {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 20px;
+    height: 20px;
+    border-bottom-left-radius: 5px;
+    background-color: rgb(56, 56, 56);
+    color: white;
+    text-align: center;
+    line-height: 20px;
+    font-size: 12px;
+    cursor: pointer;
+    z-index: 1; /* Ensure it is on top of other elements */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    &:hover {
+        background-color: red;
+    }
+}
+
 .hidden-memory-bar {
     display: none;
 }

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -305,7 +305,16 @@ body > * {
 .camera-position-memory-bar {
     background-color: rgb(50,50,50);
     border-radius: 10px;
-    padding: 5px;
+    padding: 5px 10px 5px 10px;
+    filter: drop-shadow(0 0 6px black);
+}
+
+.camera-position-memory-bar-label {
+    position: absolute;
+    top: -40px;
+    background-color: rgb(50,50,50);
+    padding: 5px 10px 5px 10px;
+    border-radius: 10px;
     filter: drop-shadow(0 0 6px black);
 }
 

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -297,20 +297,23 @@ body > * {
     justify-content: center;
     position: absolute;
     left: 0;
-    top: 150px;
+    top: 180px;
+    z-index: 100;
+    transform: translateZ(100px);
 }
 
 .camera-position-memory-bar {
-    background-color: rgba(0,0,0,0.25);
+    background-color: rgb(50,50,50);
     border-radius: 10px;
     padding: 5px;
+    filter: drop-shadow(0 0 6px black);
 }
 
 .camera-position-memory-slot {
     width: 100px;
     height: 80px;
     border: 2px solid white;
-    background-color: rgba(0,0,0,0.5);
+    background-color: rgba(25,25,25,0.5);
     border-radius: 10px;
     display: inline-block;
     margin: 10px;
@@ -337,7 +340,7 @@ body > * {
     width: 20px;
     height: 20px;
     border-bottom-left-radius: 5px;
-    background-color: rgb(56, 56, 56);
+    background-color: rgb(25,25,25);
     color: white;
     text-align: center;
     line-height: 20px;


### PR DESCRIPTION
Trying not to spend too much time for this as it's just a fun convenience feature, but I think I've covered the main functionality:
- Integrates with Dan's existing save/load camera perspectives
- Saves a thumbnail of the current splat canvas or threejs canvas in the selected slot
- Stores the perspectives per-world in localStorage, and loads them back when refreshed
- Includes some error handling to delete old thumbnails from local storage if you've exceeded a certain storage limit
- Can press the `.` key or use the menu bar item to toggle the UI

Requires: https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/745

![camera-position-memory-bar-v5](https://github.com/user-attachments/assets/7eb55483-cf4e-4b67-9730-f2c4f4559e0b)
